### PR TITLE
feat: count tool flow, element panel, assign element modal chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,26 +145,27 @@ Key behaviours:
 `ProjectWorkspaceView.tsx` renders a **PlanSwift-style canvas** layout:
 
 ```
-┌──────────────────────┬──────────────────────────────────────────┐
-│ LEFT SIDEBAR         │  TOP BAR                                 │
-│  • Header            │  🏠 > Workspace > [file] > Page N of M   │
-│  • DASHBOARD link    │                        Auto-saved just now│
-│  • TOOLS             ├──────────────────────────────────────────┤
-│    (8 tool buttons)  │  CANVAS                                  │
-│    colour palette    │  (PDF via react-pdf, img via <img>)       │
-│  • ASSEMBLIES        │  BIM/CAD shows placeholder               │
-│  • DRAWINGS          │                                          │
-│    [search box]      │  ┌───────────┐  bottom-left: zoom panel  │
-│    shadcn Accordion: │  │ - + ↔    │  bottom-right: page badge  │
-│    ▼ FOLDER [n]      │  └───────────┘  "Page N — filename"      │
-│      📄 file.pdf     │                                          │
-│        Page 1        │                                          │
-│        Page 2 ←sel   │                                          │
-│      📄 file2.pdf    │                                          │
-│    ▼ FOLDER 2 [n]    │                                          │
-│    ──────────────    │                                          │
-│    [New Folder][↑]   │                                          │
-└──────────────────────┴──────────────────────────────────────────┘
+┌──────────────────────┬──────────────────────────────────────────┬─────────────┐
+│ LEFT SIDEBAR         │  TOP BAR                                 │             │
+│  • Header            │  🏠 > Workspace > [file] > Page N of M   │  ELEMENT    │
+│  • DASHBOARD link    │                 Scale Locked | View BOQ  │  DETAIL     │
+│  • TOOLS             ├──────────────────────────────────────────┤  PANEL      │
+│    (6 tool buttons)  │  CANVAS                                  │  (count     │
+│    colour palette    │  (PDF via react-pdf, img via <img>)       │   mode only)│
+│  • ASSEMBLIES        │  BIM/CAD shows placeholder               │             │
+│    (hidden in count) │                                          │             │
+│  • DRAWINGS / ELEMENTS│  ┌───────────┐  bottom-left: zoom panel │             │
+│    [search box]      │  │ - + ↔    │  bottom-right: page badge  │             │
+│    shadcn Accordion  │  └───────────┘  "Page N — filename"      │             │
+│    OR count mode     │                                          │             │
+│    ELEMENTS panel    │                                          │             │
+│    [+ Create Elements│                                          │             │
+└──────────────────────┴──────────────────────────────────────────┴─────────────┘
+                        ┌─────────────────────────────────────────────────────────┐
+                        │ BOTTOM BAR (count mode only)                             │
+                        │  Before scale: CALIBRATION REQUIRED + known-dist input  │
+                        │  After scale:  Ready to measure + quick tips            │
+                        └─────────────────────────────────────────────────────────┘
 ```
 
 **Sidebar behaviour:**
@@ -175,12 +176,89 @@ Key behaviours:
 - Pages are populated lazily: `react-pdf`'s `onLoadSuccess` dispatches `setDrawingPages`
 - **New Folder** opens a dialog to name and create a `DrawingFolder` in Redux
 - **Upload** triggers a hidden `<input type="file">`, uploads go into the first folder
+- In **count mode**: ASSEMBLIES section hides; DRAWINGS card is replaced by ELEMENTS panel
 
 **Canvas behaviour:**
 - Breadcrumb: `🏠 > Workspace > [drawing name] > Page N of M`
 - Floating zoom panel: bottom-left (ZoomIn / ZoomOut / Reset)
 - Page badge: bottom-right — `Page N — drawing name`
 - No drawing selected → "Viewing No Drawing..." empty state
+
+**Top bar in count mode:**
+- "Scale Locked" green badge appears once calibration is applied
+- "View BOQ" amber button appears while count mode is active
+
+---
+
+### Count Tool Flow
+
+Clicking the **Count** tool triggers a sequential modal flow:
+
+1. **BBSQuestionModal** — "Does this drawing have a Bar Bending Schedule?"
+   - Yes → BBSEntryModal
+   - No / Skip → ScaleSetupModal directly
+
+2. **BBSEntryModal** — table: BAR MARK, BAR SIZE (Select), LENGTH MM, QUANTITY
+   - Save Schedule → ScaleSetupModal
+
+3. **ScaleSetupModal** — "Would you like to scale for this page?"
+   - Select what to measure (Pile / Column / Beam / etc.)
+   - Yes → count mode active + calibration bottom bar + Element Detail Panel opens
+   - No → same (scale can be set later)
+
+4. **Count mode active** changes the workspace:
+   - Bottom bar shows CALIBRATION REQUIRED → enter known distance → Apply Scale
+   - After scale applied: "Ready to measure" + Lock Scale toggle + quick tips
+   - ELEMENTS sidebar panel replaces DRAWINGS
+   - "Scale Locked" + "View BOQ" appear in top bar
+   - Element Detail Panel slides open on the right
+
+---
+
+### Element Detail Panel
+
+A `290px` right-side panel that opens immediately when `ScaleSetupModal` is dismissed (regardless of Yes/No). Renders alongside the canvas.
+
+**CONCRETE tab:**
+- Tag input, Counts (static), Shape/Depth/Diameter/Plasticizers, Color swatch
+
+**REBAR tab:**
+- Rebar Input Method radio (Read from drawing / Enter manually)
+- Main Bars table (Size Select, Number, Depth)
+- Addition Bars table (same structure, with "+ Add Bar")
+- Stirrups toggle + Size/Spacing when enabled
+- Color swatch
+
+**Footer buttons:**
+- "Apply & Continue" — logs to console (TODO: persist to element)
+- "+ Assign Element" — opens the Assign Element modal flow
+
+The panel header shows the measure type from `ScaleSetupModal` (e.g. "PILE", "COLUMN") via the `measure` prop.
+
+---
+
+### Assign Element Modal Chain
+
+Opens from "+ Assign Element" in the Element Detail Panel footer.
+
+```
+AssignItemsModal
+  ├── "Create New Element" →  CreateNewElementModal
+  │                             └── onCreate → toast + close
+  │                             └── "Use Existing" → back to AssignItemsModal
+  └── "Assign to Existing" →  ConfirmAssignmentModal
+                                └── "Confirm Merge" → AssignmentCompleteModal
+                                                        └── Close | View Element
+```
+
+- **AssignItemsModal**: radio cards (Create New / Assign to Existing), expandable element list with search
+- **ConfirmAssignmentModal**: shows current/adding/new-total preview
+- **AssignmentCompleteModal**: success state
+- **CreateNewElementModal**: category folder + measurement unit selects, "Assign Pile Parameters" table
+
+All modals support back-navigation (Cancel re-opens previous modal where appropriate).
+
+---
 
 ### Sub-pages (BOQ, Takeoff, Configuration)
 `ProjectWorkspaceLayout.tsx` detects `activeSegment`:
@@ -251,13 +329,29 @@ placeholder card. Two swap points are marked with `/* SWAP POINT */` comments:
 | `DrawingFileList` | same | Reusable file list with status |
 | `DrawingPreviewPanel` | same | Reusable preview (PDF + image + BIM placeholder) |
 | `SaveSetupModal` | same | Post-save confirmation modal |
-| `ProjectWorkspaceView` | `components/projects/workspace/` | Canvas workspace (main page) |
+| `ProjectWorkspaceView` | `components/projects/workspace/` | Canvas workspace — main component |
 | `ProjectWorkspaceLayout` | same | Layout wrapper (sidebar for sub-pages) |
 | `workspaceMapper` | same | Builds workspace snapshot from wizard state |
 | `manualWizardSlice` | `store/slices/` | Wizard Redux state |
 | `projectWorkspaceSlice` | `store/slices/` | Per-project workspace snapshots (persisted) |
 | `manualProjectApi` | `store/api/` | QS config, scope, finishing, metrics mutations |
 | `projectsApi` | `store/api/` | CRUD, file upload, BIM processing, dashboard |
+
+**Sub-components inside `ProjectWorkspaceView.tsx` (all co-located in same file):**
+
+| Component | Purpose |
+|---|---|
+| `DrawingCanvas` | Renders PDF (react-pdf), image, or BIM placeholder |
+| `FileRow` | Single drawing row + page sub-list in sidebar |
+| `NewFolderDialog` | Modal to name a new drawing folder |
+| `BBSQuestionModal` | Step 1 of Count flow — BBS yes/no |
+| `BBSEntryModal` | Step 2 — BBS data entry table |
+| `ScaleSetupModal` | Step 3 — page scale setup (measure type + yes/no) |
+| `ElementDetailPanel` | Right-side panel: CONCRETE / REBAR tabs + apply/assign footer |
+| `AssignItemsModal` | Assign flow step 1 — create new vs assign to existing |
+| `ConfirmAssignmentModal` | Assign flow step 2 — merge preview |
+| `AssignmentCompleteModal` | Assign flow step 3 — success state |
+| `CreateNewElementModal` | Alternate assign path — new element form |
 
 ---
 
@@ -288,20 +382,44 @@ placeholder card. Two swap points are marked with `/* SWAP POINT */` comments:
 
 ## Branching History (relevant)
 
-| Branch | Description |
+| Branch | Description | Remote? |
+|---|---|---|
+| `main` | Production | ✅ pushed |
+| `feat/2-step-wizard-canvas-workspace` | 2-step wizard + canvas workspace overhaul (current) | ❌ local only — DO NOT push without user confirmation |
+| `5-manual-mode-integration` | Previous 4-step wizard integration (merged) | ✅ |
+| `auth/integration` | Auth flow integration (merged) | ✅ |
+
+Latest commit on `feat/2-step-wizard-canvas-workspace`: `feat: folder/page hierarchy sidebar + redesign to match Figma spec`
+
+---
+
+## Workspace Sidebar — Visual Spec (last redesigned to match Figma)
+
+| Section | Implementation |
 |---|---|
-| `main` | Production |
-| `feat/2-step-wizard-canvas-workspace` | 2-step wizard + canvas workspace overhaul (current) |
-| `5-manual-mode-integration` | Previous 4-step wizard integration (merged) |
-| `auth/integration` | Auth flow integration (merged) |
+| Sidebar width | `w-[248px]`, `bg-white` |
+| Header | `bg-[#fdf8f0]` warm cream, amber-500 `LayoutGrid` icon (rounded-xl), bold project name + subtitle |
+| DASHBOARD | `Home` icon, bold uppercase `tracking-widest` |
+| TOOLS | `Wrench` label, 6× `w-9 h-9 rounded-lg` buttons (Length/Area/Count/Text/Undo/Redo), active = `bg-amber-500`; colour palette `h-7 rounded-lg border` |
+| ASSEMBLIES | `Box` icon + label, no placeholder text |
+| DRAWINGS card | `rounded-xl border border-slate-200 shadow-sm bg-white` inside `p-2` |
+| Card header | Amber `FolderOpen` + **"DRAWINGS"** bold + `SlidersHorizontal` filter icon |
+| FileRow active | `bg-amber-50 text-amber-700` |
+| FileRow inactive | `text-slate-600 hover:bg-slate-50` |
+| Page sub-list | `ml-6 border-l-2 border-amber-200 pl-4` |
+| Card footer | "New Folder" (outlined) + "Upload" (`bg-amber-50`) inside card |
+
+**Behaviour note:** Drawings uploaded during wizard creation auto-populate the DRAWINGS folder.
+"New Folder" and "Upload" inside the card are secondary/backup controls.
 
 ---
 
 ## Conventions
 
-- **Colours:** Primary action = amber/orange (`bg-amber-500`). Workspace bg = `#dbe3eb`. Panel bg = `#f8fafc`
+- **Colours:** Primary action = amber/orange (`bg-amber-500`). Workspace bg = `#dbe3eb`. Panel bg = `#f8fafc`. Sidebar header = `#fdf8f0`
 - **Toasts:** Use `sonner` (`toast.success`, `toast.error`, `toast.warning`)
 - **Form validation:** `react-hook-form` + `zod`
 - **Icons:** `lucide-react` only
 - **No comments** unless the WHY is non-obvious. No docstrings.
 - **Simulated data / stubs** must have a clearly marked `// TODO:` swap comment
+- **Git pushes:** Do NOT push to remote without explicit user confirmation. User has rejected pushes twice ("dont push"). Always ask before pushing.

--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -11,6 +11,7 @@ import {
   Type,
   Undo2,
   Redo2,
+  Ruler,
   Search,
   ZoomIn,
   ZoomOut,
@@ -25,13 +26,15 @@ import {
   Upload,
   Home,
   ChevronRight,
-  MousePointer2,
-  Hand,
-  LayoutDashboard,
+  Lock,
+  Plus,
   FileUp,
   Wrench,
   SlidersHorizontal,
   LayoutGrid,
+  CheckCircle2,
+  Link2,
+  X,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -45,9 +48,21 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useGetProjectByIdQuery } from "@/store/api/projectsApi";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
@@ -65,22 +80,48 @@ pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.vers
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
-type ToolId = "select" | "grab" | "markup" | "polygon" | "count" | "text" | "undo" | "redo";
+type ToolId = "length" | "area" | "count" | "text" | "undo" | "redo";
 
 const PALETTE = [
   "#ef4444", "#f97316", "#eab308", "#22c55e",
   "#3b82f6", "#8b5cf6", "#ec4899", "#64748b",
 ];
 
-const TOOLS: { id: ToolId; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
-  { id: "select",  icon: MousePointer2, label: "Select" },
-  { id: "grab",    icon: Hand,          label: "Pan" },
-  { id: "markup",  icon: PenLine,       label: "Markup" },
-  { id: "polygon", icon: Pentagon,      label: "Polygon" },
-  { id: "count",   icon: Hash,          label: "Count" },
-  { id: "text",    icon: Type,          label: "Text" },
-  { id: "undo",    icon: Undo2,         label: "Undo" },
-  { id: "redo",    icon: Redo2,         label: "Redo" },
+const TOOLS: {
+  id: ToolId;
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  description: string;
+}[] = [
+  { id: "length", icon: Ruler,   label: "Length", description: "Measure linear distances on the drawing" },
+  { id: "area",   icon: Pentagon, label: "Area",   description: "Measure polygon areas on the drawing" },
+  { id: "count",  icon: Hash,     label: "Count",  description: "Count items and elements on the drawing" },
+  { id: "text",   icon: Type,     label: "Text",   description: "Add text annotations to the drawing" },
+  { id: "undo",   icon: Undo2,    label: "Undo",   description: "Undo the last action" },
+  { id: "redo",   icon: Redo2,    label: "Redo",   description: "Redo the last undone action" },
+];
+
+interface BBSRow {
+  id: string;
+  mark: string;
+  size: string;
+  length: string;
+  quantity: string;
+}
+
+interface RebarBar {
+  id: string;
+  size: string;
+  count: string;
+  depth: string;
+}
+
+const BAR_SIZE_OPTIONS = ["Y8", "Y10", "Y12", "Y16", "Y20", "Y25", "Y32"];
+const SCALE_MEASURE_OPTIONS = ["Pile", "Column", "Beam", "Foundation", "Slab", "Wall", "Staircase"];
+
+const MOCK_EXISTING_ELEMENTS = [
+  { id: "pile",     name: "Pile",      path: "Substructure / Piles",      count: 15 },
+  { id: "pilecaps", name: "Pile Caps", path: "Substructure / Pile Caps",  count: 16 },
 ];
 
 const ACCEPTED_EXTENSIONS = [
@@ -102,12 +143,13 @@ function getExt(name: string) {
   return i >= 0 ? name.slice(i).toLowerCase() : "";
 }
 
-// ── Simulated upload (same pattern as StepDrawings — swap body for real API) ──
+// ── Simulated upload ──────────────────────────────────────────────────────────
+
 async function simulateUpload(
   file: File,
   onProgress: (p: number) => void,
 ): Promise<string> {
-  // TODO: Replace with real API call: const { url } = await uploadDrawingFile(file, { onProgress });
+  // TODO: Replace with real API call
   console.log("[WorkspaceUpload]", { name: file.name, size: file.size });
   for (let p = 10; p <= 90; p += 20) {
     await new Promise((r) => setTimeout(r, 180));
@@ -117,7 +159,7 @@ async function simulateUpload(
   return `https://cdn.placeholder.example/drawings/${encodeURIComponent(file.name)}`;
 }
 
-// ── File icon ────────────────────────────────────────────────────────────────
+// ── File icon ─────────────────────────────────────────────────────────────────
 
 function FileIcon({ category }: { category: DrawingFile["category"] }) {
   if (category === "image")  return <Image   className="w-3 h-3 shrink-0 text-blue-400" />;
@@ -126,13 +168,10 @@ function FileIcon({ category }: { category: DrawingFile["category"] }) {
   return <FileText className="w-3 h-3 shrink-0 text-orange-400" />;
 }
 
-// ── Drawing canvas ───────────────────────────────────────────────────────────
+// ── Drawing canvas ────────────────────────────────────────────────────────────
 
 function DrawingCanvas({
-  drawing,
-  page,
-  scale,
-  onPageCountResolved,
+  drawing, page, scale, onPageCountResolved,
 }: {
   drawing: DrawingFile | null;
   page: number;
@@ -147,127 +186,65 @@ function DrawingCanvas({
       </div>
     );
   }
-
   if (drawing.category === "pdf" && drawing.previewUrl) {
     return (
       <div className="flex items-start justify-center h-full overflow-auto p-6">
         <Document
           file={drawing.previewUrl}
           onLoadSuccess={({ numPages }) => onPageCountResolved(drawing.id, numPages)}
-          loading={
-            <div className="flex items-center gap-2 text-slate-400 text-sm mt-16">
-              <Loader2 className="w-4 h-4 animate-spin" /> Loading…
-            </div>
-          }
-          error={
-            <p className="text-sm text-destructive mt-16">Failed to load drawing.</p>
-          }
+          loading={<div className="flex items-center gap-2 text-slate-400 text-sm mt-16"><Loader2 className="w-4 h-4 animate-spin" /> Loading…</div>}
+          error={<p className="text-sm text-destructive mt-16">Failed to load drawing.</p>}
         >
-          <Page
-            pageNumber={page}
-            scale={scale}
-            renderTextLayer={false}
-            renderAnnotationLayer={false}
-            className="shadow-2xl"
-          />
+          <Page pageNumber={page} scale={scale} renderTextLayer={false} renderAnnotationLayer={false} className="shadow-2xl" />
         </Document>
       </div>
     );
   }
-
   if (drawing.category === "image") {
     const src = drawing.previewUrl ?? drawing.uploadedUrl;
     if (src) {
       return (
         <div className="flex items-center justify-center h-full overflow-hidden">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={src}
-            alt={drawing.name}
-            style={{ transform: `scale(${scale})`, transformOrigin: "center", transition: "transform 0.15s ease" }}
-            className="max-w-full max-h-full object-contain"
-            draggable={false}
-          />
+          <img src={src} alt={drawing.name} style={{ transform: `scale(${scale})`, transformOrigin: "center", transition: "transform 0.15s ease" }} className="max-w-full max-h-full object-contain" draggable={false} />
         </div>
       );
     }
   }
-
-  /* SWAP POINT — replace this block with <ApsViewer urn={drawing.urn} getToken={...} /> when APS subscription is active */
+  /* SWAP POINT — replace with <ApsViewer urn={drawing.urn} getToken={...} /> when APS subscription is active */
   return (
     <div className="flex flex-col items-center justify-center h-full gap-4 text-center px-8">
       <div className="w-20 h-20 rounded-2xl bg-slate-100 flex items-center justify-center">
-        {drawing.category === "bim-3d"
-          ? <Box className="w-10 h-10 text-slate-300" />
-          : <PenLine className="w-10 h-10 text-slate-300" />}
+        {drawing.category === "bim-3d" ? <Box className="w-10 h-10 text-slate-300" /> : <PenLine className="w-10 h-10 text-slate-300" />}
       </div>
       <div>
         <p className="text-sm font-semibold text-slate-500">{drawing.name}</p>
         <p className="text-xs text-slate-400 mt-1 max-w-xs">
-          {drawing.category === "bim-3d"
-            ? "3D BIM preview requires Autodesk APS subscription."
-            : "CAD preview requires viewer subscription."}
+          {drawing.category === "bim-3d" ? "3D BIM preview requires Autodesk APS subscription." : "CAD preview requires viewer subscription."}
         </p>
       </div>
     </div>
   );
 }
 
-// ── File row (with expandable pages) ────────────────────────────────────────
+// ── File row ──────────────────────────────────────────────────────────────────
 
-function FileRow({
-  file,
-  isActive,
-  activePage,
-  onSelectFile,
-  onSelectPage,
-}: {
-  file: DrawingFile;
-  isActive: boolean;
-  activePage: number;
-  onSelectFile: () => void;
-  onSelectPage: (pageNum: number) => void;
+function FileRow({ file, isActive, activePage, onSelectFile, onSelectPage }: {
+  file: DrawingFile; isActive: boolean; activePage: number;
+  onSelectFile: () => void; onSelectPage: (pageNum: number) => void;
 }) {
   const hasMultiplePages = file.pages.length > 1;
   const displayName = file.name.replace(/\.[^.]+$/, "");
-
   return (
     <div>
-      {/* File row */}
-      <button
-        onClick={onSelectFile}
-        title={displayName}
-        className={`w-full flex items-center gap-2.5 pl-6 pr-3 py-2 text-left transition-colors ${
-          isActive
-            ? "bg-amber-50 text-amber-700"
-            : "text-slate-600 hover:bg-slate-50"
-        }`}
-      >
-        <FileText
-          className={`w-3.5 h-3.5 shrink-0 ${isActive ? "text-amber-500" : "text-slate-400"}`}
-        />
-        <span
-          className={`text-[11px] truncate flex-1 ${
-            isActive ? "font-semibold text-amber-700" : "font-medium text-slate-600"
-          }`}
-        >
-          {displayName}
-        </span>
+      <button onClick={onSelectFile} title={displayName} className={`w-full flex items-center gap-2.5 pl-6 pr-3 py-2 text-left transition-colors ${isActive ? "bg-amber-50 text-amber-700" : "text-slate-600 hover:bg-slate-50"}`}>
+        <FileText className={`w-3.5 h-3.5 shrink-0 ${isActive ? "text-amber-500" : "text-slate-400"}`} />
+        <span className={`text-[11px] truncate flex-1 ${isActive ? "font-semibold text-amber-700" : "font-medium text-slate-600"}`}>{displayName}</span>
       </button>
-
-      {/* Pages sub-list — only when active and PDF has multiple pages */}
       {isActive && hasMultiplePages && (
         <div className="ml-6 border-l-2 border-amber-200">
           {file.pages.map((pg) => (
-            <button
-              key={pg.number}
-              onClick={() => onSelectPage(pg.number)}
-              className={`w-full text-left flex items-center gap-2 pl-4 pr-3 py-1.5 transition-colors ${
-                activePage === pg.number
-                  ? "text-amber-700 font-semibold bg-amber-50"
-                  : "text-slate-500 hover:bg-slate-50 hover:text-amber-600"
-              }`}
-            >
+            <button key={pg.number} onClick={() => onSelectPage(pg.number)} className={`w-full text-left flex items-center gap-2 pl-4 pr-3 py-1.5 transition-colors ${activePage === pg.number ? "text-amber-700 font-semibold bg-amber-50" : "text-slate-500 hover:bg-slate-50 hover:text-amber-600"}`}>
               <FileText className="w-2.5 h-2.5 shrink-0 text-amber-300" />
               <span className="text-[10px] truncate">{pg.label}</span>
             </button>
@@ -278,19 +255,12 @@ function FileRow({
   );
 }
 
-// ── New Folder dialog ────────────────────────────────────────────────────────
+// ── New Folder dialog ─────────────────────────────────────────────────────────
 
-function NewFolderDialog({
-  open,
-  onOpenChange,
-  onConfirm,
-}: {
-  open: boolean;
-  onOpenChange: (v: boolean) => void;
-  onConfirm: (name: string) => void;
+function NewFolderDialog({ open, onOpenChange, onConfirm }: {
+  open: boolean; onOpenChange: (v: boolean) => void; onConfirm: (name: string) => void;
 }) {
   const [name, setName] = useState("");
-
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = name.trim().toUpperCase();
@@ -299,36 +269,673 @@ function NewFolderDialog({
     setName("");
     onOpenChange(false);
   }
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-sm">New Drawing Folder</DialogTitle>
-        </DialogHeader>
+        <DialogHeader><DialogTitle className="text-sm">New Drawing Folder</DialogTitle></DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4 pt-1">
-          <Input
-            autoFocus
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. STRUCTURAL DRAWINGS"
-            className="text-sm"
-          />
-          <DialogFooter>
-            <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!name.trim()} className="bg-amber-500 hover:bg-amber-600 text-white">
-              Create Folder
-            </Button>
-          </DialogFooter>
+          <Input autoFocus value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. STRUCTURAL DRAWINGS" className="text-sm" />
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" type="button" onClick={() => onOpenChange(false)}>Cancel</Button>
+            <Button type="submit" disabled={!name.trim()} className="bg-amber-500 hover:bg-amber-600 text-white">Create Folder</Button>
+          </div>
         </form>
       </DialogContent>
     </Dialog>
   );
 }
 
-// ── Main component ───────────────────────────────────────────────────────────
+// ── BBS Question Modal ────────────────────────────────────────────────────────
+
+function BBSQuestionModal({ open, answer, onAnswerChange, onClose, onSkip, onContinue }: {
+  open: boolean; answer: "yes" | "no"; onAnswerChange: (v: "yes" | "no") => void;
+  onClose: () => void; onSkip: () => void; onContinue: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center shrink-0"><Hash className="w-5 h-5 text-amber-600" /></div>
+            <DialogTitle className="text-sm font-bold uppercase tracking-wider">Bar Bending Schedule</DialogTitle>
+          </div>
+        </DialogHeader>
+        <div className="space-y-3 py-1">
+          <p className="text-[13px] text-slate-600">Does this drawing contain a Bar Bending Schedule (BBS) or Reinforcement Table?</p>
+          <div className="space-y-2">
+            {(["yes", "no"] as const).map((v) => (
+              <button key={v} onClick={() => onAnswerChange(v)} className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg border-2 text-left transition-colors ${answer === v ? "border-amber-500 bg-amber-50" : "border-slate-200 bg-white hover:bg-slate-50"}`}>
+                <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${answer === v ? "border-amber-500" : "border-slate-300"}`}>
+                  {answer === v && <div className="w-2 h-2 rounded-full bg-amber-500" />}
+                </div>
+                <span className={`text-[13px] font-semibold ${answer === v ? "text-amber-700" : "text-slate-600"}`}>
+                  {v === "yes" ? "Yes, this drawing has a Bending Schedule" : "No, I will measure rebar manually"}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center justify-between pt-3">
+          <Button variant="outline" onClick={onSkip}>Skip</Button>
+          <Button onClick={onContinue} className="bg-amber-500 hover:bg-amber-600 text-white flex items-center gap-1.5">Continue <ChevronRight className="w-3.5 h-3.5" /></Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── BBS Entry Modal ───────────────────────────────────────────────────────────
+
+function BBSEntryModal({ open, rows, onRowChange, onAddRow, onCancel, onSave }: {
+  open: boolean; rows: BBSRow[];
+  onRowChange: (id: string, field: keyof BBSRow, value: string) => void;
+  onAddRow: () => void; onCancel: () => void; onSave: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onCancel(); }}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center shrink-0"><Hash className="w-5 h-5 text-amber-600" /></div>
+            <DialogTitle className="text-sm font-bold uppercase tracking-wider">Bar Bending Schedule</DialogTitle>
+          </div>
+        </DialogHeader>
+        <p className="text-[13px] text-slate-600">Enter the Bar Bending Schedule as shown on the drawing:</p>
+        <div className="border border-slate-200 rounded-lg overflow-hidden">
+          <div className="grid grid-cols-4 bg-slate-50 border-b border-slate-200">
+            {["Bar Mark", "Bar Size", "Length (mm)", "Quantity"].map((h) => (
+              <div key={h} className="px-3 py-2.5 text-[10px] font-bold uppercase tracking-wider text-slate-500">{h}</div>
+            ))}
+          </div>
+          <div className="divide-y divide-slate-100">
+            {rows.map((row) => (
+              <div key={row.id} className="grid grid-cols-4">
+                <div className="px-2 py-2"><Input value={row.mark} onChange={(e) => onRowChange(row.id, "mark", e.target.value)} className="h-8 text-sm" placeholder="B1" /></div>
+                <div className="px-2 py-2">
+                  <Select value={row.size} onValueChange={(v) => onRowChange(row.id, "size", v)}>
+                    <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                    <SelectContent>{BAR_SIZE_OPTIONS.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                  </Select>
+                </div>
+                <div className="px-2 py-2"><Input value={row.length} onChange={(e) => onRowChange(row.id, "length", e.target.value)} className="h-8 text-sm" placeholder="5,400" /></div>
+                <div className="px-2 py-2"><Input value={row.quantity} onChange={(e) => onRowChange(row.id, "quantity", e.target.value)} className="h-8 text-sm" placeholder="8" /></div>
+              </div>
+            ))}
+          </div>
+          <div className="px-3 py-2.5 border-t border-slate-100">
+            <button onClick={onAddRow} className="text-amber-600 hover:text-amber-700 text-[12px] font-semibold flex items-center gap-1 transition-colors">
+              <Plus className="w-3.5 h-3.5" /> Add Row
+            </button>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          <Button onClick={onSave} className="bg-amber-500 hover:bg-amber-600 text-white flex items-center gap-1.5"><Save className="w-3.5 h-3.5" /> Save Schedule</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Scale Setup Modal ─────────────────────────────────────────────────────────
+
+function ScaleSetupModal({ open, measure, onMeasureChange, onNo, onYes }: {
+  open: boolean; measure: string; onMeasureChange: (v: string) => void; onNo: () => void; onYes: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onNo(); }}>
+      <DialogContent className="max-w-sm">
+        <div className="flex flex-col items-center gap-5 py-3">
+          <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" className="text-amber-600">
+              <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+              <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.5" />
+              <line x1="12" y1="3" x2="12" y2="7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <line x1="12" y1="16.5" x2="12" y2="21" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <line x1="3" y1="12" x2="7.5" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              <line x1="16.5" y1="12" x2="21" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </div>
+          <div className="text-center">
+            <h3 className="text-base font-bold text-slate-800">Page Scale Setup</h3>
+            <p className="text-[12px] text-slate-500 mt-1">Would you like to scale for this page?</p>
+          </div>
+          <div className="w-full space-y-1.5">
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">What do you want to measure?</p>
+            <Select value={measure} onValueChange={onMeasureChange}>
+              <SelectTrigger className="w-full text-sm"><SelectValue /></SelectTrigger>
+              <SelectContent>{SCALE_MEASURE_OPTIONS.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}</SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-3 w-full">
+            <Button onClick={onYes} className="flex-1 bg-amber-500 hover:bg-amber-600 text-white">Yes, I want to Scale</Button>
+            <Button variant="outline" onClick={onNo} className="flex-1">No</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Element Detail Panel (right side) ────────────────────────────────────────
+
+function ElementDetailPanel({
+  measure = "Element",
+  onClose,
+  onAssignElement,
+  onApplyAndContinue,
+}: {
+  measure?: string;
+  onClose: () => void;
+  onAssignElement: () => void;
+  onApplyAndContinue: () => void;
+}) {
+  const [activeTab, setActiveTab] = useState<"concrete" | "rebar">("rebar");
+
+  // Concrete state
+  const [tag,          setTag]          = useState("");
+  const [shape,        setShape]        = useState("Circular");
+  const [depth,        setDepth]        = useState("1.2");
+  const [diameter,     setDiameter]     = useState("6");
+  const [plasticizers, setPlasticizers] = useState("1.2");
+
+  // Rebar state
+  const [rebarMethod,    setRebarMethod]    = useState<"read" | "manual">("manual");
+  const [mainBars,       setMainBars]       = useState<RebarBar[]>([{ id: "1", size: "Y16", count: "4", depth: "0.45" }]);
+  const [additionBars,   setAdditionBars]   = useState<RebarBar[]>([{ id: "1", size: "Y16", count: "4", depth: "0.45" }]);
+  const [inclStirrupsLocal,  setInclStirrupsLocal]  = useState(true);
+  const [stirrupSize,    setStirrupSize]    = useState("Y8");
+  const [stirrupSpacing, setStirrupSpacing] = useState("150");
+
+  function updateBar(arr: RebarBar[], setArr: (v: RebarBar[]) => void, id: string, field: keyof RebarBar, value: string) {
+    setArr(arr.map((b) => (b.id === id ? { ...b, [field]: value } : b)));
+  }
+
+  function handleApply() {
+    console.log("[ElementPanel] Apply & Continue:", {
+      tab: activeTab,
+      concrete: { tag, shape, depth, diameter, plasticizers },
+      rebar: { rebarMethod, mainBars, additionBars, stirrupsIncluded: inclStirrupsLocal, stirrupSize, stirrupSpacing },
+    });
+    onApplyAndContinue();
+  }
+
+  return (
+    <div className="w-[290px] shrink-0 bg-white border-l border-slate-200 flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 shrink-0">
+        <span className="text-sm font-bold text-slate-800 uppercase tracking-wider">{measure}</span>
+        <button onClick={onClose} className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors">
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex shrink-0 border-b border-slate-200">
+        {(["concrete", "rebar"] as const).map((tab) => (
+          <button key={tab} onClick={() => setActiveTab(tab)} className={`flex-1 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${activeTab === tab ? "text-amber-600 border-b-2 border-amber-500" : "text-slate-400 hover:text-slate-600"}`}>
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {activeTab === "concrete" ? (
+          <>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Concrete (from measurement)</p>
+
+            <div className="space-y-1">
+              <label className="text-[11px] text-slate-500">Tag this pile as:</label>
+              <Input value={tag} onChange={(e) => setTag(e.target.value)} placeholder="e.g. Bored Pile - 750mm" className="h-8 text-sm" />
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-[11px] text-slate-500">Counts</label>
+              <p className="text-base font-bold text-slate-800">18</p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-[11px] text-slate-500">Shape</label>
+                <Select value={shape} onValueChange={setShape}>
+                  <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Circular">Circular</SelectItem>
+                    <SelectItem value="Square">Square</SelectItem>
+                    <SelectItem value="Rectangular">Rectangular</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <label className="text-[11px] text-slate-500">Depth (m)</label>
+                <Input value={depth} onChange={(e) => setDepth(e.target.value)} className="h-8 text-sm" />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-[11px] text-slate-500">Diameter (m)</label>
+                <Input value={diameter} onChange={(e) => setDiameter(e.target.value)} className="h-8 text-sm" />
+              </div>
+              <div className="space-y-1">
+                <label className="text-[11px] text-slate-500">Plasticizers</label>
+                <Input value={plasticizers} onChange={(e) => setPlasticizers(e.target.value)} className="h-8 text-sm" />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-[11px] text-slate-500">Color</label>
+              <div className="h-8 rounded-lg overflow-hidden border border-slate-200 bg-blue-500 cursor-pointer" />
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Pile meta */}
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] text-slate-500">Pile: Bored Pile - 750mm</span>
+              <span className="text-[11px] text-amber-600 font-semibold">Concrete Volume: 0.81 m³</span>
+            </div>
+
+            {/* Input method */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Rebar Input Method</p>
+              <p className="text-[11px] text-slate-600">How would you like to add rebar details?</p>
+              <div className="space-y-1.5">
+                {(["read", "manual"] as const).map((m) => (
+                  <button key={m} onClick={() => setRebarMethod(m)} className="w-full flex items-center gap-2 text-left">
+                    <div className={`w-3.5 h-3.5 rounded-full border-2 flex items-center justify-center shrink-0 ${rebarMethod === m ? "border-amber-500" : "border-slate-300"}`}>
+                      {rebarMethod === m && <div className="w-1.5 h-1.5 rounded-full bg-amber-500" />}
+                    </div>
+                    <span className={`text-[11px] ${rebarMethod === m ? "text-amber-600 font-semibold" : "text-slate-500"}`}>
+                      {m === "read" ? "Read from drawing (click on rebar details on the page)" : "Enter manually (I know the rebar specifications)"}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Main bars */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Main Bars</p>
+              <p className="text-[10px] text-slate-400 uppercase tracking-wider">Rebars:</p>
+              {mainBars.map((bar) => (
+                <div key={bar.id} className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <label className="text-[10px] text-slate-400">Bars Size:</label>
+                      <Select value={bar.size} onValueChange={(v) => updateBar(mainBars, setMainBars, bar.id, "size", v)}>
+                        <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+                        <SelectContent>{BAR_SIZE_OPTIONS.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-[10px] text-slate-400">Number of bars:</label>
+                      <Input value={bar.count} onChange={(e) => updateBar(mainBars, setMainBars, bar.id, "count", e.target.value)} className="h-7 text-xs" />
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-[10px] text-slate-400">Rebar Depth (m)</label>
+                    <Input value={bar.depth} onChange={(e) => updateBar(mainBars, setMainBars, bar.id, "depth", e.target.value)} className="h-7 text-xs" />
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Addition bars */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Addition Bars:</p>
+              {additionBars.map((bar) => (
+                <div key={bar.id} className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <label className="text-[10px] text-slate-400">Bars Size:</label>
+                      <Select value={bar.size} onValueChange={(v) => updateBar(additionBars, setAdditionBars, bar.id, "size", v)}>
+                        <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+                        <SelectContent>{BAR_SIZE_OPTIONS.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                      </Select>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-[10px] text-slate-400">Number of bars:</label>
+                      <Input value={bar.count} onChange={(e) => updateBar(additionBars, setAdditionBars, bar.id, "count", e.target.value)} className="h-7 text-xs" />
+                    </div>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-[10px] text-slate-400">Rebar Depth (m)</label>
+                    <Input value={bar.depth} onChange={(e) => updateBar(additionBars, setAdditionBars, bar.id, "depth", e.target.value)} className="h-7 text-xs" />
+                  </div>
+                </div>
+              ))}
+              <button className="text-amber-600 hover:text-amber-700 text-[11px] font-semibold flex items-center gap-1">
+                <Plus className="w-3 h-3" /> Add Bar
+              </button>
+            </div>
+
+            {/* Stirrups */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Stirrups (Links/Ties)</p>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={inclStirrupsLocal}
+                  onChange={(e) => setInclStirrupsLocal(e.target.checked)}
+                  className="w-3.5 h-3.5 accent-amber-500"
+                />
+                <span className="text-[11px] text-slate-600">Include Stirrups</span>
+              </label>
+              {inclStirrupsLocal && (
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1">
+                    <label className="text-[10px] text-slate-400">Bar size:</label>
+                    <Select value={stirrupSize} onValueChange={setStirrupSize}>
+                      <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+                      <SelectContent>{BAR_SIZE_OPTIONS.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}</SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-[10px] text-slate-400">Spacing (mm c/c):</label>
+                    <Input value={stirrupSpacing} onChange={(e) => setStirrupSpacing(e.target.value)} className="h-7 text-xs" />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Color */}
+            <div className="space-y-1">
+              <label className="text-[11px] text-slate-500">Color</label>
+              <div className="h-8 rounded-lg overflow-hidden border border-slate-200 bg-blue-500 cursor-pointer" />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 border-t border-slate-200 p-3 flex gap-2">
+        <Button onClick={handleApply} className="flex-1 bg-amber-500 hover:bg-amber-600 text-white text-xs py-2">
+          Apply &amp; Continue
+        </Button>
+        <Button variant="outline" onClick={onAssignElement} className="flex-1 text-xs py-2">
+          + Assign Element
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Assign Items Modal ────────────────────────────────────────────────────────
+
+function AssignItemsModal({ open, onClose, onContinue }: {
+  open: boolean;
+  onClose: () => void;
+  onContinue: (mode: "new" | "existing", elementId?: string) => void;
+}) {
+  const [mode, setMode]           = useState<"new" | "existing">("existing");
+  const [selectedEl, setSelectedEl] = useState<string>("pile");
+  const [query, setQuery]         = useState("");
+
+  const filtered = MOCK_EXISTING_ELEMENTS.filter((e) =>
+    e.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-lg bg-amber-100 flex items-center justify-center shrink-0">
+              <Link2 className="w-4 h-4 text-amber-600" />
+            </div>
+            <div>
+              <DialogTitle className="text-sm font-bold">Assign Items</DialogTitle>
+              <p className="text-[11px] text-slate-500 font-normal mt-0.5">12 columns selected</p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <p className="text-[13px] text-slate-600">How would you like to assign these items?</p>
+
+        <div className="space-y-2">
+          {/* Create New Element card */}
+          <button
+            onClick={() => setMode("new")}
+            className={`w-full text-left border-2 rounded-xl p-3.5 flex items-start gap-3 transition-colors ${mode === "new" ? "border-amber-500 bg-amber-50" : "border-slate-200 hover:bg-slate-50"}`}
+          >
+            <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 mt-0.5 ${mode === "new" ? "border-amber-500" : "border-slate-300"}`}>
+              {mode === "new" && <div className="w-2 h-2 rounded-full bg-amber-500" />}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className={`text-[13px] font-semibold ${mode === "new" ? "text-amber-700" : "text-slate-700"}`}>Create New Element</p>
+              <p className="text-[11px] text-slate-500 mt-0.5">Define custom parameters and add these items to a brand new element in your BOQ.</p>
+            </div>
+            <div className={`w-7 h-7 rounded-lg flex items-center justify-center shrink-0 ${mode === "new" ? "bg-amber-100" : "border border-slate-200"}`}>
+              <Plus className={`w-3.5 h-3.5 ${mode === "new" ? "text-amber-600" : "text-slate-400"}`} />
+            </div>
+          </button>
+
+          {/* Assign to Existing card */}
+          <div
+            className={`border-2 rounded-xl transition-colors ${mode === "existing" ? "border-amber-500 bg-amber-50" : "border-slate-200"}`}
+          >
+            <button onClick={() => setMode("existing")} className="w-full text-left p-3.5 flex items-start gap-3">
+              <div className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 mt-0.5 ${mode === "existing" ? "border-amber-500" : "border-slate-300"}`}>
+                {mode === "existing" && <div className="w-2 h-2 rounded-full bg-amber-500" />}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className={`text-[13px] font-semibold ${mode === "existing" ? "text-amber-700" : "text-slate-700"}`}>Assign to Existing Element</p>
+                <p className="text-[11px] text-slate-500 mt-0.5">Add these counts to an element you&apos;ve already created.</p>
+              </div>
+              <div className={`w-7 h-7 rounded-lg flex items-center justify-center shrink-0 ${mode === "existing" ? "bg-amber-100" : "border border-slate-200"}`}>
+                <Link2 className={`w-3.5 h-3.5 ${mode === "existing" ? "text-amber-600" : "text-slate-400"}`} />
+              </div>
+            </button>
+
+            {mode === "existing" && (
+              <div className="px-3.5 pb-3.5 space-y-2" onClick={(e) => e.stopPropagation()}>
+                <div className="relative">
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400" />
+                  <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search existing elements..." className="h-8 pl-8 text-sm" />
+                </div>
+                <div className="space-y-1">
+                  {filtered.map((el) => (
+                    <button
+                      key={el.id}
+                      onClick={() => setSelectedEl(el.id)}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-colors ${selectedEl === el.id ? "border-amber-200 bg-white" : "border-slate-100 bg-white hover:bg-slate-50"}`}
+                    >
+                      {selectedEl === el.id
+                        ? <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                        : <div className="w-4 h-4 rounded border-2 border-slate-300 shrink-0" />
+                      }
+                      <div className="flex-1 min-w-0 text-left">
+                        <p className="text-[12px] font-semibold text-slate-700">{el.name}</p>
+                        <p className="text-[10px] text-slate-400">{el.path}</p>
+                      </div>
+                      <span className="text-[11px] text-slate-500 shrink-0">{el.count} items</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button onClick={() => onContinue(mode, mode === "existing" ? selectedEl : undefined)} className="bg-amber-500 hover:bg-amber-600 text-white">Continue</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Confirm Assignment Modal ──────────────────────────────────────────────────
+
+function ConfirmAssignmentModal({ open, onCancel, onConfirm }: {
+  open: boolean; onCancel: () => void; onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onCancel(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader><DialogTitle className="text-sm font-bold">Confirm Assignment</DialogTitle></DialogHeader>
+        <p className="text-[13px] text-slate-600">You are about to add 12 columns to the existing element:</p>
+        <div className="border border-slate-200 rounded-xl p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="w-5 h-5 border-2 border-slate-300 rounded shrink-0" />
+            <span className="text-sm font-semibold text-slate-800">Piles</span>
+          </div>
+          <div className="space-y-2 text-[13px]">
+            <div className="flex justify-between"><span className="text-slate-500">Current items</span><span className="text-slate-700">15 Piles</span></div>
+            <div className="flex justify-between"><span className="text-slate-500">Adding</span><span className="text-amber-600 font-semibold">+ 2 Piles</span></div>
+            <div className="h-px bg-slate-100" />
+            <div className="flex justify-between font-semibold"><span className="text-slate-700">New total</span><span className="text-slate-800">27 items</span></div>
+          </div>
+        </div>
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={onCancel}>Cancel</Button>
+          <Button onClick={onConfirm} className="bg-amber-500 hover:bg-amber-600 text-white">Confirm Merge</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Assignment Complete Modal ─────────────────────────────────────────────────
+
+function AssignmentCompleteModal({ open, onClose, onViewElement }: {
+  open: boolean; onClose: () => void; onViewElement: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm font-bold">
+            <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" /> Assignment Complete
+          </DialogTitle>
+        </DialogHeader>
+        <p className="text-[13px] text-slate-600">Successfully added 12 Piles to:</p>
+        <div className="border border-slate-200 rounded-xl p-4 space-y-1.5">
+          <div className="flex items-center gap-2">
+            <div className="w-5 h-5 border-2 border-slate-300 rounded shrink-0" />
+            <span className="text-sm font-semibold text-slate-800">Piles</span>
+          </div>
+          <p className="text-[12px] text-slate-500 pl-7">Now contains: 15 Piles + 2 Piles = 17 items</p>
+        </div>
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={onClose}>Close</Button>
+          <Button onClick={onViewElement} className="bg-amber-500 hover:bg-amber-600 text-white">View Element</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Create New Element Modal ──────────────────────────────────────────────────
+
+interface PileRow { id: string; name: string; count: string; volume: string; }
+
+function CreateNewElementModal({ open, onClose, onUseExisting, onCreate }: {
+  open: boolean; onClose: () => void; onUseExisting: () => void; onCreate: () => void;
+}) {
+  const [categoryFolder,   setCategoryFolder]   = useState("Substructure / Pile");
+  const [measurementUnit,  setMeasurementUnit]  = useState("Counts");
+  const [pileRows, setPileRows] = useState<PileRow[]>([
+    { id: "1", name: "Bored Pile - 750mm", count: "18", volume: "4.50" },
+    { id: "2", name: "Bored Pile - 600mm", count: "4",  volume: "4.50" },
+    { id: "3", name: "Bored Pile - 450mm", count: "4",  volume: "4.50" },
+  ]);
+
+  function updatePileRow(id: string, field: keyof PileRow, value: string) {
+    setPileRows((rows) => rows.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+  }
+
+  function handleCreate() {
+    console.log("[CreateNewElement]", { categoryFolder, measurementUnit, pileRows });
+    toast.success("Element created");
+    onCreate();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col">
+        <DialogHeader className="shrink-0">
+          <DialogTitle className="text-base font-bold">Create New Element</DialogTitle>
+          <p className="text-[12px] text-slate-500">Define custom parameters and sub-items</p>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-5 pr-1">
+          {/* Basic Details */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-bold text-slate-800">Basic Details</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <label className="text-[11px] text-slate-500">Category folder</label>
+                <Select value={categoryFolder} onValueChange={setCategoryFolder}>
+                  <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Substructure / Pile">Substructure / Pile</SelectItem>
+                    <SelectItem value="Substructure / Pile Caps">Substructure / Pile Caps</SelectItem>
+                    <SelectItem value="Substructure / Ground Beams">Substructure / Ground Beams</SelectItem>
+                    <SelectItem value="Superstructure / Columns">Superstructure / Columns</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-[11px] text-slate-500">Measurement Unit</label>
+                <Select value={measurementUnit} onValueChange={setMeasurementUnit}>
+                  <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Counts">Counts</SelectItem>
+                    <SelectItem value="m³">m³</SelectItem>
+                    <SelectItem value="m²">m²</SelectItem>
+                    <SelectItem value="m">m (linear)</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          {/* Parameters table */}
+          <div className="border border-slate-200 rounded-xl overflow-hidden">
+            <div className="px-4 py-3 bg-slate-50 border-b border-slate-200">
+              <p className="text-[11px] font-bold uppercase tracking-wider text-slate-600">Assign Pile Parameters</p>
+            </div>
+            <div className="grid grid-cols-3 border-b border-slate-100 bg-white">
+              {["Pile", "Count", "Volume Per Pile"].map((h) => (
+                <div key={h} className="px-4 py-2 text-[10px] font-bold uppercase text-slate-400 tracking-wider">{h}</div>
+              ))}
+            </div>
+            {pileRows.map((row) => (
+              <div key={row.id} className="grid grid-cols-3 border-b border-slate-50 last:border-0">
+                <div className="px-4 py-3 text-[13px] text-slate-600 flex items-center">{row.name}</div>
+                <div className="px-3 py-2 flex items-center">
+                  <Input value={row.count} onChange={(e) => updatePileRow(row.id, "count", e.target.value)} className="h-8 text-sm w-20" />
+                </div>
+                <div className="px-3 py-2 flex items-center gap-2">
+                  <Input value={row.volume} onChange={(e) => updatePileRow(row.id, "volume", e.target.value)} className="h-8 text-sm w-24" />
+                  <span className="text-[11px] text-slate-500">m³</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between pt-4 border-t border-slate-100 shrink-0">
+          <button onClick={onUseExisting} className="text-[13px] font-semibold text-amber-600 hover:text-amber-700 transition-colors">
+            Use Existing Element
+          </button>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={onClose}>Cancel</Button>
+            <Button onClick={handleCreate} className="bg-amber-500 hover:bg-amber-600 text-white flex items-center gap-1.5">
+              Create Element <ChevronRight className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 interface ProjectWorkspaceViewProps {
   projectId: string;
@@ -346,25 +953,130 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   const projectName = backendProject?.name ?? `Project ${projectId.slice(0, 8)}`;
 
-  // ── Local UI state ────────────────────────────────────────────────────────
-  const [activeTool,        setActiveTool]        = useState<ToolId>("select");
+  // ── Local UI state ──────────────────────────────────────────────────────────
+  const [activeTool,        setActiveTool]        = useState<ToolId>("length");
   const [activeColor,       setActiveColor]        = useState(PALETTE[0]);
   const [search,            setSearch]             = useState("");
   const [selectedDrawingId, setSelectedDrawingId]  = useState<string | null>(null);
   const [selectedPage,      setSelectedPage]       = useState(1);
   const [scale,             setScale]              = useState(1.0);
   const [newFolderOpen,     setNewFolderOpen]      = useState(false);
-  // Tracks which folder ids are open in the accordion
-  const [openFolders, setOpenFolders] = useState<string[]>(() => folders.map((f) => f.id));
+  const [openFolders,       setOpenFolders]        = useState<string[]>(() => folders.map((f) => f.id));
+
+  // Count tool BBS flow
+  const [bbsModalStep,   setBbsModalStep]   = useState<"question" | "entry" | null>(null);
+  const [bbsAnswer,      setBbsAnswer]      = useState<"yes" | "no">("yes");
+  const [bbsRows,        setBbsRows]        = useState<BBSRow[]>([{ id: "1", mark: "", size: "Y16", length: "", quantity: "" }]);
+  const [showScaleSetup, setShowScaleSetup] = useState(false);
+  const [scaleWhat,      setScaleWhat]      = useState("Pile");
+  const [countModeActive, setCountModeActive] = useState(false);
+  const [knownDistance,  setKnownDistance]  = useState("");
+  const [distanceUnit,   setDistanceUnit]   = useState("Meters");
+  const [scaleLocked,    setScaleLocked]    = useState(false);
+  const [scaleInfo,      setScaleInfo]      = useState<string | null>(null);
+
+  // Element detail panel
+  const [showElementPanel, setShowElementPanel] = useState(false);
+
+  // Assign element flow
+  const [assignModalOpen,    setAssignModalOpen]    = useState(false);
+  const [confirmAssignOpen,  setConfirmAssignOpen]  = useState(false);
+  const [assignCompleteOpen, setAssignCompleteOpen] = useState(false);
+  const [createNewElOpen,    setCreateNewElOpen]    = useState(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const selectedDrawing = drawings.find((d) => d.id === selectedDrawingId) ?? null;
 
-  // ── Helpers ───────────────────────────────────────────────────────────────
+  // ── Tool click ───────────────────────────────────────────────────────────────
 
-  const zoomIn  = () => setScale((s) => Math.min(+(s + 0.25).toFixed(2), 3));
-  const zoomOut = () => setScale((s) => Math.max(+(s - 0.25).toFixed(2), 0.25));
+  function handleToolClick(id: ToolId) {
+    if (id === "count") {
+      setActiveTool("count");
+      setBbsModalStep("question");
+      return;
+    }
+    if (countModeActive) setCountModeActive(false);
+    setActiveTool(id);
+  }
+
+  // ── BBS question ─────────────────────────────────────────────────────────────
+
+  function handleBBSClose()    { setBbsModalStep(null); setActiveTool("length"); }
+  function handleBBSSkip()     { setBbsModalStep(null); setShowScaleSetup(true); }
+  function handleBBSContinue() {
+    if (bbsAnswer === "yes") { setBbsModalStep("entry"); }
+    else { setBbsModalStep(null); setShowScaleSetup(true); }
+  }
+
+  // ── BBS entry ────────────────────────────────────────────────────────────────
+
+  function handleBBSEntryCancel() { setBbsModalStep(null); setActiveTool("length"); }
+  function handleBBSSave() {
+    console.log("[CountTool] BBS saved:", bbsRows);
+    toast.success("Bar Bending Schedule saved");
+    setBbsModalStep(null);
+    setShowScaleSetup(true);
+  }
+  function handleBBSRowChange(id: string, field: keyof BBSRow, value: string) {
+    setBbsRows((rows) => rows.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+  }
+  function handleAddBBSRow() {
+    setBbsRows((rows) => [...rows, { id: crypto.randomUUID(), mark: "", size: "Y16", length: "", quantity: "" }]);
+  }
+
+  // ── Scale setup ──────────────────────────────────────────────────────────────
+
+  function handleScaleSetupComplete(withCalibration: boolean) {
+    console.log(withCalibration
+      ? `[CountTool] Scale setup — with calibration. Measure: ${scaleWhat}`
+      : "[CountTool] Scale setup — skipped"
+    );
+    setShowScaleSetup(false);
+    setCountModeActive(true);
+    setShowElementPanel(true);
+  }
+
+  // ── Calibration ──────────────────────────────────────────────────────────────
+
+  function handleApplyScale() {
+    if (!knownDistance) { toast.warning("Enter a known distance first"); return; }
+    console.log("[CountTool] Apply scale:", { distance: knownDistance, unit: distanceUnit });
+    setScaleInfo("Scale calculated: 1:100 | 10.5 px per cm");
+    setScaleLocked(true);
+    toast.success("Scale applied");
+  }
+  function handleResetScale() {
+    setScaleInfo(null);
+    setKnownDistance("");
+    setScaleLocked(false);
+    console.log("[CountTool] Scale reset");
+  }
+
+  // ── Assign element flow ───────────────────────────────────────────────────────
+
+  function handleAssignContinue(mode: "new" | "existing", elementId?: string) {
+    setAssignModalOpen(false);
+    console.log("[AssignElement] mode:", mode, "elementId:", elementId);
+    if (mode === "existing") {
+      setConfirmAssignOpen(true);
+    } else {
+      setCreateNewElOpen(true);
+    }
+  }
+  function handleConfirmMerge() {
+    setConfirmAssignOpen(false);
+    setAssignCompleteOpen(true);
+  }
+  function handleCreateNewEl() {
+    setCreateNewElOpen(false);
+    toast.success("Element created and items assigned");
+  }
+
+  // ── Canvas helpers ────────────────────────────────────────────────────────────
+
+  const zoomIn    = () => setScale((s) => Math.min(+(s + 0.25).toFixed(2), 3));
+  const zoomOut   = () => setScale((s) => Math.max(+(s - 0.25).toFixed(2), 0.25));
   const resetZoom = () => setScale(1.0);
 
   function handleSelectFile(fileId: string) {
@@ -373,34 +1085,16 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setSelectedPage(1);
     setScale(1.0);
   }
-
   function handleSelectPage(fileId: string, pageNum: number) {
-    if (selectedDrawingId !== fileId) {
-      setSelectedDrawingId(fileId);
-      setScale(1.0);
-    }
+    if (selectedDrawingId !== fileId) { setSelectedDrawingId(fileId); setScale(1.0); }
     setSelectedPage(pageNum);
   }
 
-  // Called by react-pdf when a document finishes loading
-  const handlePageCountResolved = useCallback(
-    (id: string, numPages: number) => {
-      const drawing = drawings.find((d) => d.id === id);
-      if (!drawing || drawing.pageCount === numPages) return;
-      dispatch(
-        setDrawingPages({
-          id,
-          pages: Array.from({ length: numPages }, (_, i) => ({
-            number: i + 1,
-            label: `Page ${i + 1}`,
-          })),
-        }),
-      );
-    },
-    [dispatch, drawings],
-  );
-
-  // ── New folder ────────────────────────────────────────────────────────────
+  const handlePageCountResolved = useCallback((id: string, numPages: number) => {
+    const drawing = drawings.find((d) => d.id === id);
+    if (!drawing || drawing.pageCount === numPages) return;
+    dispatch(setDrawingPages({ id, pages: Array.from({ length: numPages }, (_, i) => ({ number: i + 1, label: `Page ${i + 1}` })) }));
+  }, [dispatch, drawings]);
 
   function handleCreateFolder(name: string) {
     const id = crypto.randomUUID();
@@ -409,30 +1103,17 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     toast.success(`Folder "${name}" created`);
   }
 
-  // ── Upload from workspace ─────────────────────────────────────────────────
-
   async function handleWorkspaceUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files ?? []);
     if (!files.length) return;
     e.target.value = "";
-
     const targetFolderId = folders[0]?.id ?? "default";
-
     for (const file of files) {
       const ext = getExt(file.name);
       const category = EXT_CATEGORY[ext] ?? "pdf";
       const id = crypto.randomUUID();
-      const previewUrl =
-        category === "pdf" || category === "image" ? URL.createObjectURL(file) : undefined;
-
-      dispatch(
-        addDrawing({
-          id, name: file.name, size: file.size, extension: ext,
-          category, status: "uploading", progress: 0, previewUrl,
-          folderId: targetFolderId,
-        }),
-      );
-
+      const previewUrl = category === "pdf" || category === "image" ? URL.createObjectURL(file) : undefined;
+      dispatch(addDrawing({ id, name: file.name, size: file.size, extension: ext, category, status: "uploading", progress: 0, previewUrl, folderId: targetFolderId }));
       try {
         const url = await simulateUpload(file, (progress) => {
           dispatch({ type: "manualWizard/updateDrawing", payload: { id, progress, status: "uploading" } });
@@ -448,25 +1129,17 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     }
   }
 
-  // ── Filter drawings by search ─────────────────────────────────────────────
-
   function getFilesForFolder(folder: DrawingFolder) {
     return folder.fileIds
       .map((id) => drawings.find((d) => d.id === id))
       .filter((d): d is DrawingFile => !!d && d.name.toLowerCase().includes(search.toLowerCase()));
   }
 
-  // ── Breadcrumb segments ───────────────────────────────────────────────────
-
   const breadcrumb = [
     { label: "Workspace" },
     ...(selectedDrawing ? [{ label: selectedDrawing.name.replace(/\.[^.]+$/, "") }] : []),
-    ...(selectedDrawing && selectedPage > 0
-      ? [{ label: `Page ${selectedPage}${selectedDrawing.pageCount ? ` of ${selectedDrawing.pageCount}` : ""}` }]
-      : []),
+    ...(selectedDrawing && selectedPage > 0 ? [{ label: `Page ${selectedPage}${selectedDrawing.pageCount ? ` of ${selectedDrawing.pageCount}` : ""}` }] : []),
   ];
-
-  // ── Loading state ─────────────────────────────────────────────────────────
 
   if (isLoading && !backendProject) {
     return (
@@ -481,12 +1154,13 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   return (
     <div className="flex h-screen overflow-hidden bg-[#e8edf2]">
+
       {/* ═══════════════════════════════════════════════════════════════════════
           LEFT SIDEBAR
       ═══════════════════════════════════════════════════════════════════════ */}
       <aside className="w-[248px] shrink-0 bg-white border-r border-slate-100 flex flex-col overflow-hidden">
 
-        {/* ── Header ── */}
+        {/* Header */}
         <div className="px-3 py-3 bg-[#fdf8f0] border-b border-amber-100/60 flex items-center gap-2.5">
           <div className="w-9 h-9 rounded-xl bg-amber-500 flex items-center justify-center shrink-0 shadow-sm">
             <LayoutGrid className="w-4.5 h-4.5 text-white" />
@@ -497,269 +1171,364 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
           </div>
         </div>
 
-        {/* ── DASHBOARD ── */}
+        {/* Dashboard */}
         <div className="px-3 py-1 border-b border-slate-100">
-          <a
-            href={basePath.startsWith("/enterprise") ? "/enterprise/dashboard" : "/dashboard"}
-            className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors"
-          >
+          <a href={basePath.startsWith("/enterprise") ? "/enterprise/dashboard" : "/dashboard"} className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors">
             <Home className="w-4 h-4 shrink-0" />
             <span className="text-[11px] font-bold uppercase tracking-widest">Dashboard</span>
           </a>
         </div>
 
-        {/* ── TOOLS ── */}
+        {/* Tools */}
         <div className="px-3 pt-3 pb-2.5 border-b border-slate-100">
           <div className="flex items-center gap-1.5 mb-2.5">
             <Wrench className="w-3.5 h-3.5 text-slate-400" />
             <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Tools</span>
           </div>
-          <div className="flex gap-1.5">
-            {TOOLS.map((tool) => (
-              <button
-                key={tool.id}
-                title={tool.label}
-                onClick={() => setActiveTool(tool.id)}
-                className={`w-9 h-9 flex items-center justify-center rounded-lg border transition-colors ${
-                  activeTool === tool.id
-                    ? "bg-slate-700 border-slate-700 text-white shadow-sm"
-                    : "bg-white border-slate-200 text-slate-500 hover:bg-slate-50 hover:border-slate-300"
-                }`}
-              >
-                <tool.icon className="w-4 h-4" />
-              </button>
-            ))}
-          </div>
-          {/* Colour palette — keep as-is per user instruction */}
+          <TooltipProvider delayDuration={400}>
+            <div className="flex gap-1.5">
+              {TOOLS.map((tool) => (
+                <Tooltip key={tool.id}>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => handleToolClick(tool.id)}
+                      className={`w-9 h-9 flex items-center justify-center rounded-lg border transition-colors ${
+                        activeTool === tool.id
+                          ? "bg-amber-500 border-amber-500 text-white shadow-sm"
+                          : "bg-white border-slate-200 text-slate-500 hover:bg-slate-50 hover:border-slate-300"
+                      }`}
+                    >
+                      <tool.icon className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={6}>
+                    <p className="font-semibold text-xs">{tool.label}</p>
+                    <p className="text-[10px] opacity-75 mt-0.5">{tool.description}</p>
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
+          </TooltipProvider>
+
+          {/* Active tool indicator */}
+          {countModeActive && activeTool === "count" && (
+            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+              <span className="text-white text-[11px] font-semibold">Count</span>
+              <span className="text-white text-[11px] font-bold"># 0</span>
+            </div>
+          )}
+          {activeTool === "length" && (
+            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+              <span className="text-white text-[11px] font-semibold">Length</span>
+              <span className="text-white text-[11px] font-bold">0</span>
+            </div>
+          )}
+
+          {/* Colour palette */}
           <div className="mt-2.5 h-7 rounded-lg flex overflow-hidden border border-slate-200">
             {PALETTE.map((c) => (
-              <button
-                key={c}
-                title={c}
-                onClick={() => setActiveColor(c)}
-                style={{ backgroundColor: c, flex: 1 }}
-                className={`h-full transition-opacity ${
-                  activeColor === c ? "ring-2 ring-inset ring-white/70 opacity-100" : "opacity-85 hover:opacity-100"
-                }`}
-              />
+              <button key={c} title={c} onClick={() => setActiveColor(c)} style={{ backgroundColor: c, flex: 1 }} className={`h-full transition-opacity ${activeColor === c ? "ring-2 ring-inset ring-white/70 opacity-100" : "opacity-85 hover:opacity-100"}`} />
             ))}
           </div>
         </div>
 
-        {/* ── ASSEMBLIES ── */}
-        <div className="px-3 py-2.5 border-b border-slate-100">
-          <div className="flex items-center gap-1.5">
-            <Box className="w-3.5 h-3.5 text-slate-400" />
-            <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Assemblies</span>
+        {/* Assemblies — hidden in count mode */}
+        {!countModeActive && (
+          <div className="px-3 py-2.5 border-b border-slate-100">
+            <div className="flex items-center gap-1.5">
+              <Box className="w-3.5 h-3.5 text-slate-400" />
+              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Assemblies</span>
+            </div>
           </div>
-        </div>
+        )}
 
-        {/* ── DRAWINGS card — flex-1, white rounded card with shadow ── */}
-        <div className="flex-1 min-h-0 p-2 flex flex-col overflow-hidden">
-          <div className="flex-1 min-h-0 rounded-xl border border-slate-200 bg-white shadow-sm flex flex-col overflow-hidden">
-
-            {/* Card header */}
-            <div className="flex items-center justify-between px-3 py-2.5 border-b border-slate-100 shrink-0">
-              <div className="flex items-center gap-2">
-                <FolderOpen className="w-4 h-4 text-amber-500 shrink-0" />
-                <span className="text-[12px] font-bold text-slate-800 tracking-wide">DRAWINGS</span>
-              </div>
-              <button className="text-slate-400 hover:text-slate-600 transition-colors p-0.5 rounded">
-                <SlidersHorizontal className="w-3.5 h-3.5" />
-              </button>
-            </div>
-
-            {/* Search */}
-            <div className="px-2 py-2 border-b border-slate-100 shrink-0">
-              <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
-                <Input
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search drawings..."
-                  className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white"
-                />
-              </div>
-            </div>
-
-            {/* Folder accordion — scrollable */}
-            <div className="flex-1 overflow-y-auto">
-              {folders.length === 0 || drawings.filter(d => d.status === "complete" || d.previewUrl).length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-8 px-4 text-center gap-2">
-                  <FolderOpen className="w-8 h-8 text-slate-200" />
-                  <p className="text-[11px] text-slate-400 leading-relaxed">
-                    No drawings uploaded yet.<br />Use Upload below to add files.
-                  </p>
+        {/* Elements panel (always visible, replaces Assemblies in count mode) */}
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          {countModeActive ? (
+            /* Count mode: full ELEMENTS panel */
+            <div className="flex-1 min-h-0 p-2 flex flex-col overflow-hidden">
+              <div className="flex-1 min-h-0 rounded-xl border border-slate-200 bg-white shadow-sm flex flex-col overflow-hidden">
+                <div className="px-3 py-2.5 border-b border-slate-100 shrink-0">
+                  <span className="text-[12px] font-bold text-slate-800 tracking-wide">ELEMENTS</span>
                 </div>
-              ) : (
-                <Accordion
-                  type="multiple"
-                  value={openFolders}
-                  onValueChange={setOpenFolders}
-                  className="border-0 rounded-none shadow-none overflow-visible"
-                >
-                  {folders.map((folder) => {
-                    const files = getFilesForFolder(folder);
-                    if (files.length === 0 && search) return null;
-                    return (
-                      <AccordionItem
-                        key={folder.id}
-                        value={folder.id}
-                        className="border-0"
-                      >
-                        <AccordionTrigger className="px-3 py-2 hover:no-underline hover:bg-slate-50 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:text-slate-400 [&>svg]:shrink-0 gap-2 border-0">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-                            <span className="text-[11px] font-bold text-slate-700 truncate uppercase tracking-wide">
-                              {folder.name}
-                            </span>
-                            <span className="text-[9px] text-slate-400 shrink-0 font-medium">
-                              [{folder.fileIds.length}]
-                            </span>
-                          </div>
-                        </AccordionTrigger>
-
-                        <AccordionContent className="px-0 pb-1 pt-0">
-                          {files.length === 0 ? (
-                            <p className="text-[10px] text-slate-400 px-5 py-1.5 italic">No files</p>
-                          ) : (
-                            <div className="flex flex-col">
-                              {files.map((file) => (
-                                <FileRow
-                                  key={file.id}
-                                  file={file}
-                                  isActive={selectedDrawingId === file.id}
-                                  activePage={selectedPage}
-                                  onSelectFile={() => handleSelectFile(file.id)}
-                                  onSelectPage={(pg) => handleSelectPage(file.id, pg)}
-                                />
-                              ))}
-                            </div>
-                          )}
-                        </AccordionContent>
-                      </AccordionItem>
-                    );
-                  })}
-                </Accordion>
-              )}
+                <div className="px-2 py-2 border-b border-slate-100 shrink-0">
+                  <div className="relative">
+                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
+                    <Input placeholder="Search..." className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white" />
+                  </div>
+                </div>
+                <div className="flex-1 flex items-center justify-center px-4">
+                  <button
+                    onClick={() => setShowElementPanel(true)}
+                    className="flex items-center gap-1.5 text-amber-600 hover:text-amber-700 text-[12px] font-semibold transition-colors"
+                  >
+                    <Plus className="w-3.5 h-3.5" /> Create Elements
+                  </button>
+                </div>
+              </div>
             </div>
-
-            {/* New Folder + Upload — inside card at bottom */}
-            <div className="shrink-0 border-t border-slate-100 flex items-center gap-2 p-2">
-              <button
-                onClick={() => setNewFolderOpen(true)}
-                className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border border-slate-200 text-[11px] font-medium text-slate-600 hover:bg-slate-50 transition-colors"
-              >
-                <FolderPlus className="w-3.5 h-3.5" />
-                New Folder
-              </button>
-              <button
-                onClick={() => fileInputRef.current?.click()}
-                className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-amber-50 border border-amber-200 text-[11px] font-semibold text-amber-600 hover:bg-amber-100 transition-colors"
-              >
-                <Upload className="w-3.5 h-3.5" />
-                Upload
-              </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                accept={ACCEPTED_EXTENSIONS.join(",")}
-                className="hidden"
-                onChange={handleWorkspaceUpload}
-              />
+          ) : (
+            /* Normal mode: DRAWINGS card */
+            <div className="flex-1 min-h-0 p-2 flex flex-col overflow-hidden">
+              <div className="flex-1 min-h-0 rounded-xl border border-slate-200 bg-white shadow-sm flex flex-col overflow-hidden">
+                <div className="flex items-center justify-between px-3 py-2.5 border-b border-slate-100 shrink-0">
+                  <div className="flex items-center gap-2">
+                    <FolderOpen className="w-4 h-4 text-amber-500 shrink-0" />
+                    <span className="text-[12px] font-bold text-slate-800 tracking-wide">DRAWINGS</span>
+                  </div>
+                  <button className="text-slate-400 hover:text-slate-600 transition-colors p-0.5 rounded">
+                    <SlidersHorizontal className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                <div className="px-2 py-2 border-b border-slate-100 shrink-0">
+                  <div className="relative">
+                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
+                    <Input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search drawings..." className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white" />
+                  </div>
+                </div>
+                <div className="flex-1 overflow-y-auto">
+                  {folders.length === 0 || drawings.filter(d => d.status === "complete" || d.previewUrl).length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-8 px-4 text-center gap-2">
+                      <FolderOpen className="w-8 h-8 text-slate-200" />
+                      <p className="text-[11px] text-slate-400 leading-relaxed">No drawings uploaded yet.<br />Use Upload below to add files.</p>
+                    </div>
+                  ) : (
+                    <Accordion type="multiple" value={openFolders} onValueChange={setOpenFolders} className="border-0 rounded-none shadow-none overflow-visible">
+                      {folders.map((folder) => {
+                        const files = getFilesForFolder(folder);
+                        if (files.length === 0 && search) return null;
+                        return (
+                          <AccordionItem key={folder.id} value={folder.id} className="border-0">
+                            <AccordionTrigger className="px-3 py-2 hover:no-underline hover:bg-slate-50 [&>svg]:w-3 [&>svg]:h-3 [&>svg]:text-slate-400 [&>svg]:shrink-0 gap-2 border-0">
+                              <div className="flex items-center gap-2 min-w-0">
+                                <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                                <span className="text-[11px] font-bold text-slate-700 truncate uppercase tracking-wide">{folder.name}</span>
+                                <span className="text-[9px] text-slate-400 shrink-0 font-medium">[{folder.fileIds.length}]</span>
+                              </div>
+                            </AccordionTrigger>
+                            <AccordionContent className="px-0 pb-1 pt-0">
+                              {files.length === 0
+                                ? <p className="text-[10px] text-slate-400 px-5 py-1.5 italic">No files</p>
+                                : <div className="flex flex-col">{files.map((file) => (<FileRow key={file.id} file={file} isActive={selectedDrawingId === file.id} activePage={selectedPage} onSelectFile={() => handleSelectFile(file.id)} onSelectPage={(pg) => handleSelectPage(file.id, pg)} />))}</div>
+                              }
+                            </AccordionContent>
+                          </AccordionItem>
+                        );
+                      })}
+                    </Accordion>
+                  )}
+                </div>
+                <div className="shrink-0 border-t border-slate-100 flex items-center gap-2 p-2">
+                  <button onClick={() => setNewFolderOpen(true)} className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border border-slate-200 text-[11px] font-medium text-slate-600 hover:bg-slate-50 transition-colors">
+                    <FolderPlus className="w-3.5 h-3.5" /> New Folder
+                  </button>
+                  <button onClick={() => fileInputRef.current?.click()} className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-amber-50 border border-amber-200 text-[11px] font-semibold text-amber-600 hover:bg-amber-100 transition-colors">
+                    <Upload className="w-3.5 h-3.5" /> Upload
+                  </button>
+                  <input ref={fileInputRef} type="file" multiple accept={ACCEPTED_EXTENSIONS.join(",")} className="hidden" onChange={handleWorkspaceUpload} />
+                </div>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </aside>
 
       {/* ═══════════════════════════════════════════════════════════════════════
-          RIGHT: BREADCRUMB + CANVAS
+          RIGHT: TOP BAR + CANVAS ROW + BOTTOM BAR
       ═══════════════════════════════════════════════════════════════════════ */}
       <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
 
-        {/* Top breadcrumb bar */}
+        {/* Top bar */}
         <header className="h-10 shrink-0 bg-white border-b border-slate-200 flex items-center justify-between px-4">
           <nav className="flex items-center gap-1 text-[11px] text-slate-500 min-w-0">
             <Home className="w-3 h-3 shrink-0 text-slate-400" />
             {breadcrumb.map((seg, i) => (
               <span key={i} className="flex items-center gap-1 min-w-0">
                 <ChevronRight className="w-3 h-3 shrink-0 text-slate-300" />
-                <span
-                  className={`truncate max-w-[140px] ${
-                    i === breadcrumb.length - 1 ? "text-slate-700 font-semibold" : ""
-                  }`}
-                >
-                  {seg.label}
-                </span>
+                <span className={`truncate max-w-[140px] ${i === breadcrumb.length - 1 ? "text-slate-700 font-semibold" : ""}`}>{seg.label}</span>
               </span>
             ))}
           </nav>
-
-          <div className="flex items-center gap-3 shrink-0">
+          <div className="flex items-center gap-2.5 shrink-0">
             <span className="flex items-center gap-1 text-[10px] text-slate-400">
-              <Save className="w-3 h-3" />
-              Auto-saved just now
+              <Save className="w-3 h-3" /> Auto-saved just now
             </span>
+            {scaleLocked && (
+              <div className="flex items-center gap-1.5 px-2.5 py-1 bg-green-100 rounded-lg border border-green-200">
+                <Lock className="w-3 h-3 text-green-600" />
+                <span className="text-[10px] font-semibold text-green-700">Scale Locked</span>
+              </div>
+            )}
+            {countModeActive && (
+              <button onClick={() => console.log("[BOQ] View BOQ")} className="flex items-center gap-1.5 px-3 py-1 bg-amber-500 hover:bg-amber-600 rounded-lg text-white text-[11px] font-semibold transition-colors">
+                <FileUp className="w-3 h-3" /> View BOQ
+              </button>
+            )}
           </div>
         </header>
 
-        {/* Canvas area */}
-        <div className="flex-1 min-h-0 relative overflow-hidden bg-[#e8edf2]">
-          <DrawingCanvas
-            drawing={selectedDrawing}
-            page={selectedPage}
-            scale={scale}
-            onPageCountResolved={handlePageCountResolved}
-          />
+        {/* Canvas row (canvas + optional element panel) */}
+        <div className="flex-1 min-h-0 flex overflow-hidden">
+          {/* Canvas */}
+          <div className="flex-1 min-w-0 relative overflow-hidden bg-[#e8edf2]">
+            <DrawingCanvas drawing={selectedDrawing} page={selectedPage} scale={scale} onPageCountResolved={handlePageCountResolved} />
 
-          {/* Floating zoom controls — bottom-left of canvas */}
-          <div className="absolute bottom-4 left-4 flex flex-col gap-1 bg-white rounded-lg shadow-md border border-slate-200 p-1">
-            <button
-              onClick={zoomIn}
-              disabled={scale >= 3}
-              className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40"
-              title="Zoom in"
-            >
-              <ZoomIn className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={zoomOut}
-              disabled={scale <= 0.25}
-              className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40"
-              title="Zoom out"
-            >
-              <ZoomOut className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={resetZoom}
-              className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500"
-              title="Reset zoom"
-            >
-              <Maximize2 className="w-3.5 h-3.5" />
-            </button>
+            {/* Zoom controls */}
+            <div className="absolute bottom-4 left-4 flex flex-col gap-1 bg-white rounded-lg shadow-md border border-slate-200 p-1">
+              <button onClick={zoomIn} disabled={scale >= 3} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40" title="Zoom in"><ZoomIn className="w-3.5 h-3.5" /></button>
+              <button onClick={zoomOut} disabled={scale <= 0.25} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40" title="Zoom out"><ZoomOut className="w-3.5 h-3.5" /></button>
+              <button onClick={resetZoom} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500" title="Reset zoom"><Maximize2 className="w-3.5 h-3.5" /></button>
+            </div>
+
+            {/* Page indicator */}
+            {selectedDrawing && (
+              <div className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-white rounded-lg shadow-md border border-slate-200 px-3 py-1.5 text-[11px] text-slate-600 font-medium">
+                <FileUp className="w-3.5 h-3.5 text-amber-500" />
+                Page {selectedPage}
+                {selectedDrawing.name && <span className="text-slate-400">— {selectedDrawing.name.replace(/\.[^.]+$/, "")}</span>}
+              </div>
+            )}
           </div>
 
-          {/* Page indicator — bottom-right of canvas */}
-          {selectedDrawing && (
-            <div className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-white rounded-lg shadow-md border border-slate-200 px-3 py-1.5 text-[11px] text-slate-600 font-medium">
-              <FileUp className="w-3.5 h-3.5 text-amber-500" />
-              Page {selectedPage}
-              {selectedDrawing.name && (
-                <span className="text-slate-400">
-                  — {selectedDrawing.name.replace(/\.[^.]+$/, "")}
-                </span>
-              )}
-            </div>
+          {/* Element detail panel */}
+          {showElementPanel && (
+            <ElementDetailPanel
+              measure={scaleWhat}
+              onClose={() => setShowElementPanel(false)}
+              onAssignElement={() => setAssignModalOpen(true)}
+              onApplyAndContinue={() => { console.log("[ElementPanel] Apply & Continue"); }}
+            />
           )}
         </div>
+
+        {/* Bottom bar — count mode only */}
+        {countModeActive && (
+          <div className="shrink-0 bg-white border-t border-slate-200">
+            {!scaleInfo ? (
+              /* Calibration panel */
+              <div className="px-6 py-3 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+                    <span className="text-[11px] font-bold tracking-wide text-red-600">CALIBRATION REQUIRED</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-slate-500">Lock Scale:</span>
+                    <button onClick={() => setScaleLocked((v) => !v)} className={`relative w-9 h-5 rounded-full transition-colors ${scaleLocked ? "bg-amber-500" : "bg-slate-200"}`}>
+                      <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200 ${scaleLocked ? "translate-x-4" : "translate-x-0.5"}`} />
+                    </button>
+                    <span className="text-[11px] font-semibold text-slate-500">{scaleLocked ? "ON" : "OFF"}</span>
+                  </div>
+                </div>
+                <div className="flex items-start gap-10">
+                  <div className="flex items-start gap-2">
+                    <div className="w-5 h-5 rounded-full bg-amber-500 text-white flex items-center justify-center text-[10px] font-bold shrink-0">1</div>
+                    <span className="text-[11px] text-slate-600">Click two points on a known distance on the plan.</span>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <div className="w-5 h-5 rounded-full bg-amber-500 text-white flex items-center justify-center text-[10px] font-bold shrink-0">2</div>
+                    <span className="text-[11px] text-slate-600">Enter the real length below.</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 flex-wrap">
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500 whitespace-nowrap">Known Distance on Plan</span>
+                  <Input value={knownDistance} onChange={(e) => setKnownDistance(e.target.value)} className="h-8 w-36 text-sm" placeholder="0" />
+                  <Select value={distanceUnit} onValueChange={setDistanceUnit}>
+                    <SelectTrigger className="h-8 w-28 text-[11px]"><SelectValue /></SelectTrigger>
+                    <SelectContent>{["Meters", "mm", "cm", "ft"].map((u) => <SelectItem key={u} value={u}>{u}</SelectItem>)}</SelectContent>
+                  </Select>
+                  <Button onClick={handleApplyScale} className="h-8 bg-amber-500 hover:bg-amber-600 text-white text-[11px] px-4">Apply Scale</Button>
+                </div>
+              </div>
+            ) : (
+              /* Ready to measure panel */
+              <div>
+                <div className="flex items-center justify-between px-6 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                    <span className="text-[11px] font-semibold text-green-600">Ready to measure. Click line tool and trace any wall.</span>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[11px] text-slate-500">Lock Scale:</span>
+                      <button onClick={() => setScaleLocked((v) => !v)} className={`relative w-9 h-5 rounded-full transition-colors ${scaleLocked ? "bg-green-500" : "bg-slate-200"}`}>
+                        <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200 ${scaleLocked ? "translate-x-4" : "translate-x-0.5"}`} />
+                      </button>
+                      <span className={`text-[11px] font-bold ${scaleLocked ? "text-green-600" : "text-slate-500"}`}>{scaleLocked ? "ON" : "OFF"}</span>
+                    </div>
+                    <button onClick={handleResetScale} className="text-[11px] text-slate-500 hover:text-slate-700 font-medium transition-colors">
+                      Edit Calibration
+                    </button>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 px-6 py-2 bg-amber-50/60 border-t border-amber-100">
+                  <span className="text-amber-500 text-sm">💡</span>
+                  <span className="text-[10px] font-semibold text-slate-500">Quick tips:</span>
+                  {["Press L for line tool", "A for area", "C for count", "Double-click to finish polygon", "Right-click to cancel"].map((tip, i) => (
+                    <span key={i} className="text-[10px] text-slate-400 flex items-center gap-2">
+                      {i > 0 && <span className="text-slate-300">•</span>}
+                      {tip}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* ── Dialogs ── */}
-      <NewFolderDialog
-        open={newFolderOpen}
-        onOpenChange={setNewFolderOpen}
-        onConfirm={handleCreateFolder}
+      <NewFolderDialog open={newFolderOpen} onOpenChange={setNewFolderOpen} onConfirm={handleCreateFolder} />
+
+      <BBSQuestionModal
+        open={bbsModalStep === "question"}
+        answer={bbsAnswer}
+        onAnswerChange={setBbsAnswer}
+        onClose={handleBBSClose}
+        onSkip={handleBBSSkip}
+        onContinue={handleBBSContinue}
+      />
+
+      <BBSEntryModal
+        open={bbsModalStep === "entry"}
+        rows={bbsRows}
+        onRowChange={handleBBSRowChange}
+        onAddRow={handleAddBBSRow}
+        onCancel={handleBBSEntryCancel}
+        onSave={handleBBSSave}
+      />
+
+      <ScaleSetupModal
+        open={showScaleSetup}
+        measure={scaleWhat}
+        onMeasureChange={setScaleWhat}
+        onNo={() => handleScaleSetupComplete(false)}
+        onYes={() => handleScaleSetupComplete(true)}
+      />
+
+      <AssignItemsModal
+        open={assignModalOpen}
+        onClose={() => setAssignModalOpen(false)}
+        onContinue={handleAssignContinue}
+      />
+
+      <ConfirmAssignmentModal
+        open={confirmAssignOpen}
+        onCancel={() => { setConfirmAssignOpen(false); setAssignModalOpen(true); }}
+        onConfirm={handleConfirmMerge}
+      />
+
+      <AssignmentCompleteModal
+        open={assignCompleteOpen}
+        onClose={() => setAssignCompleteOpen(false)}
+        onViewElement={() => { setAssignCompleteOpen(false); console.log("[Assignment] View element"); }}
+      />
+
+      <CreateNewElementModal
+        open={createNewElOpen}
+        onClose={() => setCreateNewElOpen(false)}
+        onUseExisting={() => { setCreateNewElOpen(false); setAssignModalOpen(true); }}
+        onCreate={handleCreateNewEl}
       />
     </div>
   );


### PR DESCRIPTION
- Add full Count tool modal sequence: BBS Question → BBS Entry → Scale Setup → count mode
- Add Element Detail Panel (right side, 290px) with CONCRETE/REBAR tabs; opens immediately on scale setup completion
- Add Assign Element modal chain: AssignItems → ConfirmAssignment → AssignmentComplete / CreateNewElement
- Active tool state uses amber-500 (matching Figma)
- Bottom bar switches between calibration and ready-to-measure states
- DRY: merge handleScaleSetupYes/No into handleScaleSetupComplete(withCalibration)
- Fix: ElementDetailPanel header is now dynamic via measure prop (no more hardcoded "Pile")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added element assignment workflow with multi-step confirmation modals
  * Introduced Element Detail Panel for managing element properties
  * Enhanced drawing preview support for PDF and image files
  * Added calibration tools for measurement mode workflows
  * Redesigned sidebar with dynamic Drawings and Elements view modes

* **Documentation**
  * Updated workspace specifications and component documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->