### PR TITLE
feat: category-driven element creation flow, floating panels, and sca…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,6 +615,7 @@ export function MultiFormatViewer({ url }: { url: string }) {
 | `StepScope`, `StepFinishing`, `StepMetrics` still exist | `components/projects/manual/` | Removed from wizard flow but files not deleted — safe to clean up |
 | `app/layout.tsx` has a modification | `app/` | Review before next push |
 | Drawing upload is simulated | `StepDrawings.tsx` | Swap point clearly marked with TODO comment |
+| View BOQ finalize — exact failure mode unknown | `ProjectWorkspaceView.tsx` | Button now shows specific error toasts (404/400/5xx); user needs to report which one appears |
 
 ---
 
@@ -628,6 +629,213 @@ export function MultiFormatViewer({ url }: { url: string }) {
 | `auth/integration` | Auth flow integration (merged) | ✅ |
 
 Latest commit on `feat/2-step-wizard-canvas-workspace`: `feat: count tool flow, element panel, assign element modal chain` (`738e845`)
+
+---
+
+---
+
+## Session — Workspace Fixes & Auto-Save (2026-07-18 → 2026-07-20)
+
+### 1. Source Dropdown on Manual Project Creation
+
+Added a `source` field to the manual project creation form (Step 2).
+
+- `PROJECT_SOURCES` constant in `components/projects/manual/constants.ts` — values: `manual`, `manual-drawn`, `pdf_boq`, `bim`, `template`
+- `source: string` added to `Step2Data` interface (`components/projects/manual/types.ts`)
+- `source: z.string().optional()` added to zod schema in `StepProjectDetails.tsx`
+- `CreateManualProjectPayload.source` widened from `"manual"` literal to `string` (`types/manualProject.ts`)
+- Transformer: `source: step2.source || "manual"` (`manualWizardTransformers.ts`)
+
+---
+
+### 2. Drawing Hydration Fix (document not showing in workspace)
+
+**Root cause:** `backendProject.drawings` is empty for freshly-created projects. `DrawingHydrator` was never rendering.
+
+**Fix:** `apiHydrateIds` in `ProjectWorkspaceView.tsx` now merges `backendProject.drawings` AND `savedSession.drawings` (from localStorage written by the wizard before navigation):
+
+```typescript
+const apiHydrateIds = useMemo(() => {
+  const ids = new Set<string>(backendProject?.drawings ?? []);
+  for (const d of savedSession.drawings ?? []) ids.add(d.id);
+  return Array.from(ids);
+}, [backendProject?.drawings, savedSession.drawings]);
+```
+
+`drawingsOpen` panel also auto-opens when `savedSession.drawings` is non-empty.
+
+---
+
+### 3. Color Picker Fix (Fix #2)
+
+**Root cause:** Radix `<Select>` + `<SelectItem>` with `<div>` children causes a div-inside-span DOM nesting violation that prevents click events from registering.
+
+**Fix:** Replaced both color pickers (Concrete tab and Rebar tab) in `ElementDetailPanel.tsx` with inline clickable `<button>` circles — no more Radix Select involved:
+
+```tsx
+<div className="flex gap-1.5 flex-wrap py-1">
+  {PALETTE.map((c) => (
+    <button
+      key={c} type="button" onClick={() => onColorChange?.(c)}
+      title={PALETTE_LABELS[c] ?? c}
+      className={`w-6 h-6 rounded-full border-2 transition-all ${
+        (activeColor ?? PALETTE[0]) === c
+          ? "border-white ring-2 ring-slate-400 scale-110"
+          : "border-transparent hover:scale-110"
+      }`}
+      style={{ backgroundColor: c }}
+    />
+  ))}
+</div>
+```
+
+`PALETTE_LABELS` constant added to `components/projects/workspace/components/constants.ts` maps hex → human-readable name.
+
+---
+
+### 4. Cross-Page Element Visibility (Fix #1)
+
+**Root cause:** Phase 2 hydration only loaded elements from the *current* active session. Switching pages wiped the Elements tab.
+
+**Architecture change:** Phase 2 is now split into two:
+
+**Phase 2 (unchanged in role):** Per-session canvas/calibration restore only (scale factor, canvas marks, known distance). Runs once per `activeSessionId`.
+
+**Global element loader (new):** Runs once when `backendProject._id` first resolves. Fetches ALL project sessions in parallel via `fetchProjectSessions` + `fetchSessionById`, then merges ALL `_snapshot`-bearing elements across every session into a single global `elements` state. The Elements tab now shows work from every page simultaneously.
+
+```typescript
+const projectElementsLoaded = useRef(false);
+useEffect(() => {
+  if (projectElementsLoaded.current || !backendProject?._id) return;
+  projectElementsLoaded.current = true;
+  async function loadAllElements() {
+    const sessionsResult = await fetchProjectSessions(projectId);
+    // ... fetch all sessions in parallel, merge assigned + pending elements
+  }
+  loadAllElements();
+}, [backendProject?._id, projectId]);
+```
+
+---
+
+### 5. Undo/Redo Disabled State + Keyboard Shortcuts (Fix #3)
+
+- Undo/Redo buttons in TOOLS bar are now `disabled` when `measurementHook.canUndo` / `canRedo` is false. Styling: `disabled:opacity-40 disabled:cursor-not-allowed`.
+- Keyboard shortcuts added: `Cmd/Ctrl+Z` = undo, `Cmd/Ctrl+Shift+Z` or `Ctrl+Y` = redo. Wired via `useEffect` + `window.addEventListener("keydown", ...)`.
+
+---
+
+### 6. Skip BBS/Scale Prompts on Page Navigation (Fix #4)
+
+**Problem:** Navigating to another page and clicking a tool triggered the full BBS → Scale Setup modal chain again, as if starting from scratch.
+
+**Fix:** `handleToolClick` now checks `scaleFlowActive` first. If scale is already configured (from any previous page or session restore), clicking a tool directly activates it:
+
+```typescript
+function handleToolClick(id: ToolId) {
+  if (id === "undo") { measurementHook.undo(); return; }
+  if (id === "redo") { measurementHook.redo(); return; }
+  if (scaleFlowActive) {
+    setActiveTool(id);
+    setCountModeActive(id === "count");
+    setPendingTool(null);
+    return;
+  }
+  setPendingTool(id);
+  setBbsModalStep("question");
+}
+```
+
+`scaleFlowActive` persists across page navigation (component-level state, only reset by `handleResetScale`).
+
+---
+
+### 7. Apply Scale ≠ Lock Scale
+
+**Problem:** Clicking "Apply Scale" immediately locked the scale (`setScaleLocked(true)` was called inside `handleApplyScale`), bypassing the explicit "Lock Scale" toggle.
+
+**Fix:** Removed `setScaleLocked(true)` and `scaleLocked: true` from `handleApplyScale`. The user must now explicitly toggle Lock Scale after confirming they are happy with the calibration.
+
+Status header in the calibration bar now changes dynamically:
+- Before apply: red dot + "CALIBRATION REQUIRED"
+- After apply, before lock: amber dot + "SCALE APPLIED — Lock when ready"
+- After lock: separate "Ready to measure" bar (unchanged)
+
+---
+
+### 8. Auto-Save (Continuous Variant Persistence)
+
+**Problem:** The `concreteMeasurements` array (fed to `CreateNewElementModal`) was only populated when the user explicitly clicked "Apply & Continue". If they skipped that step and clicked "+ Assign Element", the modal showed empty.
+
+**Solution:** Auto-save fires on every canvas mark and on every form field change.
+
+#### Architecture
+
+**`currentVariantId` ref** — stable UUID for the current measurement round. Used as `clientId` when upserting to backend so repeated saves are idempotent. Cycles (new UUID) when "Apply & Continue" is explicitly clicked.
+
+**`handleAutoSave(formPayload?)`** in `ProjectWorkspaceView.tsx`:
+- Builds a `WsConcreteMeasurement` using `currentVariantId.current` as ID
+- Upserts/updates the entry in `concreteMeasurements` (no duplicates)
+- Calls `upsertPendingVariant` to persist to backend
+- Updates `autoSaveStatus`: `idle → saving → saved → idle`
+
+**Canvas mark trigger:** `useEffect` on `measurementHook.state.measurements.length` — fires `handleAutoSave()` whenever a new mark is placed.
+
+**Form field trigger:** `onFormChange` prop added to `ElementDetailPanel`. A `useEffect` inside the panel watches all form state (tag, concrete fields, rebar bars, stirrups) and fires `onFormChange` with a 700 ms debounce.
+
+**"Apply & Continue" integration:** Now uses `currentVariantId.current` (same ID as auto-saves) to update the existing entry in place, then cycles to a new UUID. No duplicates ever appear.
+
+#### Navbar autosave indicator
+
+```tsx
+{autoSaveStatus === "saving" ? (
+  <span className="flex items-center gap-1 text-[10px] text-amber-500">
+    <div className="w-2.5 h-2.5 border border-amber-400 border-t-transparent rounded-full animate-spin" />
+    Saving...
+  </span>
+) : (
+  <span className="flex items-center gap-1 text-[10px] text-slate-400">
+    <Save className="w-3 h-3" /> Auto-saved just now
+  </span>
+)}
+```
+
+#### localStorage fixes
+
+- `concreteMeasurements: []` removed from the on-mount localStorage wipe so pending measurements survive page refresh.
+- Global element loader falls back to `loadSession(projectId).concreteMeasurements` if backend returns no pending variants.
+
+#### Assign Element guard
+
+If `concreteMeasurements` is somehow still empty when "+ Assign Element" is clicked (no drawings yet), a toast fires: "Take a measurement on the drawing first."
+
+---
+
+### 9. View BOQ — Error Visibility
+
+**Problem:** Clicking "View BOQ" did nothing visible.
+
+**Fix:** `handleViewBoq` now:
+- Shows a warning toast if `activeSessionId` is null ("No active session")
+- On API failure, shows a specific toast: 404 = "Session not found", 400 = "Cannot finalize: ensure at least one measurement is saved", otherwise shows the HTTP status code
+- Navigation to `/boq` only happens on API success
+
+**Status:** Root cause of the actual failure still unknown — user needs to check DevTools Network tab for the HTTP status on `POST /measurement-sessions/:id/finalize`.
+
+---
+
+### Key Files Modified This Session
+
+| File | What changed |
+|---|---|
+| `components/projects/manual/types.ts` | Added `source: string` to `Step2Data` |
+| `components/projects/manual/constants.ts` | Added `PROJECT_SOURCES`, `source: ""` default |
+| `components/projects/manual/StepProjectDetails.tsx` | Source dropdown with Radix Select |
+| `components/projects/manual/manualWizardTransformers.ts` | `source: step2.source \|\| "manual"` |
+| `types/manualProject.ts` | Widened `source` to `string` |
+| `components/projects/workspace/ProjectWorkspaceView.tsx` | Major — all session, auto-save, hydration, BBS/scale fixes |
+| `components/projects/workspace/components/ElementDetailPanel.tsx` | Color swatch grid, `onFormChange` prop, debounced form auto-save |
+| `components/projects/workspace/components/constants.ts` | Added `PALETTE_LABELS` |
 
 ---
 

--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -7,6 +7,7 @@ import {
   ZoomIn,
   ZoomOut,
   Maximize2,
+  Minimize2,
   FolderOpen,
   FolderPlus,
   Upload,
@@ -46,8 +47,15 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useRouter } from "next/navigation";
-import { useGetProjectByIdQuery, useUpdateProjectMutation } from "@/store/api/projectsApi";
-import { useUploadFileMutation, useGetUploadQuery, useDownloadUploadQuery } from "@/store/api/uploadApi";
+import {
+  useGetProjectByIdQuery,
+  useUpdateProjectMutation,
+} from "@/store/api/projectsApi";
+import {
+  useUploadFileMutation,
+  useGetUploadQuery,
+  useDownloadUploadQuery,
+} from "@/store/api/uploadApi";
 import {
   useCreateMeasurementSessionMutation,
   useGetMeasurementSessionQuery,
@@ -60,7 +68,10 @@ import {
   useLazyGetMeasurementSessionQuery,
   useDeleteMeasurementSessionMutation,
 } from "@/store/api/measurementSessionApi";
-import type { MeasurementElement as BackendMeasurementElement, UpsertElementBody } from "@/types/measurementSession";
+import type {
+  MeasurementElement as BackendMeasurementElement,
+  UpsertElementBody,
+} from "@/types/measurementSession";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import {
   addDrawing,
@@ -90,7 +101,7 @@ const MeasurementCanvas = dynamic(
     import("./components/MeasurementCanvas").then((m) => ({
       default: m.MeasurementCanvas,
     })),
-  { ssr: false }
+  { ssr: false },
 );
 import { BBSQuestionModal } from "./components/BBSQuestionModal";
 import { BBSEntryModal } from "./components/BBSEntryModal";
@@ -101,9 +112,25 @@ import { AssignItemsModal } from "./components/AssignItemsModal";
 import { ConfirmAssignmentModal } from "./components/ConfirmAssignmentModal";
 import { AssignmentCompleteModal } from "./components/AssignmentCompleteModal";
 import { CreateNewElementModal } from "./components/CreateNewElementModal";
-import { PALETTE, TOOLS, ACCEPTED_EXTENSIONS, EXT_CATEGORY } from "./components/constants";
+import {
+  PALETTE,
+  TOOLS,
+  ACCEPTED_EXTENSIONS,
+  EXT_CATEGORY,
+  ELEMENT_CONFIGS,
+  LINTEL_LENGTH_BONUS_M,
+} from "./components/constants";
 import { getExt } from "./components/utils";
-import type { ToolId, BBSRow, PileRow, CreatedElement, Measurement, LengthMeasurement, AreaMeasurement, CountMark } from "./components/types";
+import type {
+  ToolId,
+  BBSRow,
+  PileRow,
+  CreatedElement,
+  Measurement,
+  LengthMeasurement,
+  AreaMeasurement,
+  CountMark,
+} from "./components/types";
 import { elementTotalDisplay } from "./components/types";
 
 // ── Measurement ↔ backend element converters ──────────────────────────────────
@@ -134,27 +161,31 @@ function backendElementToMeasurement(
   }
 
   if (el.tool === "length" && pts.length >= 2) {
-    return [{
-      id: el.clientId,
-      type: "length" as const,
-      points: pts.map(([x, y]) => ({ x, y })),
-      pixelLength: el.computed?.lengthPx ?? 0,
-      realLength: el.computed?.length ?? 0,
-      unit: "m",
-      color: HYDRATION_COLOR,
-    }];
+    return [
+      {
+        id: el.clientId,
+        type: "length" as const,
+        points: pts.map(([x, y]) => ({ x, y })),
+        pixelLength: el.computed?.lengthPx ?? 0,
+        realLength: el.computed?.length ?? 0,
+        unit: "m",
+        color: HYDRATION_COLOR,
+      },
+    ];
   }
 
   if (el.tool === "area" && pts.length >= 3) {
-    return [{
-      id: el.clientId,
-      type: "area" as const,
-      points: pts.map(([x, y]) => ({ x, y })),
-      pixelArea: el.computed?.areaPx ?? 0,
-      realArea: el.computed?.area ?? 0,
-      unit: "m²",
-      color: HYDRATION_COLOR,
-    }];
+    return [
+      {
+        id: el.clientId,
+        type: "area" as const,
+        points: pts.map(([x, y]) => ({ x, y })),
+        pixelArea: el.computed?.areaPx ?? 0,
+        realArea: el.computed?.area ?? 0,
+        unit: "m²",
+        color: HYDRATION_COLOR,
+      },
+    ];
   }
 
   return [];
@@ -187,48 +218,57 @@ function measurementToBackendBody(m: Measurement): UpsertElementBody {
 function toBackendElementType(measureType: string): string {
   const map: Record<string, string> = {
     // Substructure
-    "Pile":                        "pile",
-    "Pile Cap":                    "pile_cap",
-    "Pile Cap Frames":             "pile_cap_frames",
-    "Column in Foundation":        "column_in_foundation",
-    "Column Footing":              "column_footing",
-    "Pad Footing":                 "pad_footing",
-    "Ground Beam":                 "ground_beam",
-    "Excavation Ground Beam":      "excavation_ground_beam",
-    "Strip":                       "strip_foundation",
-    "Strip Foundation":            "strip_foundation",
-    "Strip Length Calculator":     "strip_length_calculator",
-    "Excavation Strip":            "excavation_strip",
-    "Raft Foundation":             "raft_foundation",
-    "Oversite Slab":               "oversite_slab",
-    "Ground Floor Bed":            "ground_floor_bed",
-    "Ground Floor Bed Void":       "ground_floor_bed_void",
-    "Water Slab":                  "water_slab",
-    "Swimming Pool":               "swimming_pool",
+    Piles: "pile",
+    Pile: "pile",
+    "Pile Cap": "pile_cap",
+    "Ground Beam / Raft": "ground_beam",
+    "Column Base / Pad": "pad_footing",
+    "Stud Column / Column in Foundation": "column_in_foundation",
+    "Ground Floor Slab": "ground_floor_bed",
+    "Pile Cap Frames": "pile_cap_frames",
+    "Column in Foundation": "column_in_foundation",
+    "Column Footing": "column_footing",
+    "Pad Footing": "pad_footing",
+    "Ground Beam": "ground_beam",
+    "Excavation Ground Beam": "excavation_ground_beam",
+    Strip: "strip_foundation",
+    "Strip Foundation": "strip_foundation",
+    "Strip Length Calculator": "strip_length_calculator",
+    "Excavation Strip": "excavation_strip",
+    "Raft Foundation": "raft_foundation",
+    "Oversite Slab": "oversite_slab",
+    "Ground Floor Bed": "ground_floor_bed",
+    "Ground Floor Bed Void": "ground_floor_bed_void",
+    "Water Slab": "water_slab",
+    "Swimming Pool": "swimming_pool",
     "Deduction: Pad Pit in Strip": "ddt_pad_pit_in_strip",
-    "Excavation Clearing":         "excavation_clearing",
+    "Excavation Clearing": "excavation_clearing",
     // Superstructure
-    "Column":                      "column",
-    "Beam":                        "beam",
-    "Roof Beams":                  "roof_beam",
-    "Roof Column":                 "roof_column",
-    "Slabs":                       "slab",
-    "Roof Slab":                   "roof_slab",
-    "Upper Floor Void":            "upper_floor_ddt_void",
-    "Wall":                        "wall",
-    "Shear Wall":                  "shear_wall",
-    "Lift Wall":                   "lift_wall",
-    "Lift Shaft":                  "lift_shaft",
-    "Lintels":                     "lintels",
-    "Staircase":                   "staircase",
-    "Staircase Landing":           "staircase_landing",
-    "Staircase Strings & Steps":   "staircase_strings_steps",
-    "Staircase Upper Floors":      "staircase_upper_floors",
+    Column: "column",
+    Columns: "column",
+    Beam: "beam",
+    "Floor Beams": "beam",
+    "Roof Beams": "roof_beam",
+    "Roof Column": "roof_column",
+    Slabs: "slab",
+    "Upper Floor Slab": "slab",
+    "Roof Slab": "roof_slab",
+    "Upper Floor Void": "upper_floor_ddt_void",
+    Wall: "wall",
+    "Shear Wall": "shear_wall",
+    "Lift Wall": "lift_wall",
+    "Lift Shaft": "lift_shaft",
+    Lintel: "lintels",
+    Lintels: "lintels",
+    Staircase: "staircase",
+    "Staircase Landing": "staircase_landing",
+    "Staircase Strings & Steps": "staircase_strings_steps",
+    "Staircase Upper Floors": "staircase_upper_floors",
     // Roof / Finishing
-    "Roof Upstands / Parapet":     "parapet_wall",
-    "Parapet Wall":                "parapet_wall",
-    "Parapet Wall Coping":         "parapet_wall_copping",
-    "Kitchen Countertop":          "kitchen_countertop",
+    "Roof Upstands / Parapet": "parapet_wall",
+    "Parapet Wall": "parapet_wall",
+    "Parapet Wall Coping": "parapet_wall_copping",
+    "Kitchen Countertop": "kitchen_countertop",
   };
   return map[measureType] ?? measureType.toLowerCase().replace(/[\s/]+/g, "_");
 }
@@ -256,7 +296,6 @@ function rebarToReinforcement(
   return result.length > 0 ? result : undefined;
 }
 
-
 function DrawingHydrator({
   fileId,
   folderId,
@@ -268,14 +307,19 @@ function DrawingHydrator({
 }) {
   const dispatch = useAppDispatch();
   const existsInRedux = useAppSelector((s) =>
-    s.manualWizard.drawings.some((d) => d.id === fileId || d.uploadedFileId === fileId),
+    s.manualWizard.drawings.some(
+      (d) => d.id === fileId || d.uploadedFileId === fileId,
+    ),
   );
   const { data: metaData } = useGetUploadQuery(fileId, { skip: existsInRedux });
-  const { data: blobUrl } = useDownloadUploadQuery(fileId, { skip: existsInRedux });
+  const { data: blobUrl } = useDownloadUploadQuery(fileId, {
+    skip: existsInRedux,
+  });
   const dispatched = useRef(false);
 
   useEffect(() => {
-    if (dispatched.current || existsInRedux || !metaData?.data || !blobUrl) return;
+    if (dispatched.current || existsInRedux || !metaData?.data || !blobUrl)
+      return;
     dispatched.current = true;
 
     const file = metaData.data;
@@ -309,9 +353,13 @@ interface ProjectWorkspaceViewProps {
   mode?: string;
 }
 
-export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceViewProps) {
+export function ProjectWorkspaceView({
+  projectId,
+  basePath,
+}: ProjectWorkspaceViewProps) {
   const dispatch = useAppDispatch();
-  const { data: projectResponse, isLoading } = useGetProjectByIdQuery(projectId);
+  const { data: projectResponse, isLoading } =
+    useGetProjectByIdQuery(projectId);
   const backendProject = projectResponse?.data;
 
   const drawings = useAppSelector((state) => state.manualWizard.drawings);
@@ -326,7 +374,8 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const hydratedSessionIds = useRef<Set<string>>(new Set());
 
   const [createMeasurementSession] = useCreateMeasurementSessionMutation();
-  const [updateMeasurementCanvas] = useUpdateMeasurementCanvasMutation();
+  const [updateMeasurementCanvas, { isLoading: applyingScale }] =
+    useUpdateMeasurementCanvasMutation();
   const [updateSessionStatus] = useUpdateMeasurementSessionStatusMutation();
   const [upsertMeasurementElement] = useUpsertMeasurementElementMutation();
   const [deleteMeasurementElement] = useDeleteMeasurementElementMutation();
@@ -341,11 +390,15 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     pageNumber?: number;
   } | null>(null);
 
-  const { data: activeSessionData } = useGetMeasurementSessionQuery(activeSessionId ?? "", {
-    skip: !activeSessionId,
-  });
+  const { data: activeSessionData } = useGetMeasurementSessionQuery(
+    activeSessionId ?? "",
+    {
+      skip: !activeSessionId,
+    },
+  );
 
-  const projectName = backendProject?.name ?? `Project ${projectId.slice(0, 8)}`;
+  const projectName =
+    backendProject?.name ?? `Project ${projectId.slice(0, 8)}`;
 
   // Selects the first drawing that arrives from DrawingHydrator (API path)
   const firstDrawingSelected = useRef(false);
@@ -365,22 +418,49 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const [pendingTool, setPendingTool] = useState<ToolId | null>(null);
   const [activeColor, setActiveColor] = useState(PALETTE[0]);
   const [search, setSearch] = useState("");
-  const [selectedDrawingId, setSelectedDrawingId] = useState<string | null>(() => drawings[0]?.id ?? null);
+  const [selectedDrawingId, setSelectedDrawingId] = useState<string | null>(
+    () => drawings[0]?.id ?? null,
+  );
   const [selectedPage, setSelectedPage] = useState(1);
   const [scale, setScale] = useState(1.0);
   const [newFolderOpen, setNewFolderOpen] = useState(false);
-  const [openFolders, setOpenFolders] = useState<string[]>(() => folders.map((f) => f.id));
+  const [openFolders, setOpenFolders] = useState<string[]>(() =>
+    folders.map((f) => f.id),
+  );
 
   // Count tool BBS flow — UI preferences, kept in localStorage
-  const [bbsModalStep, setBbsModalStep] = useState<"question" | "entry" | null>(null);
-  const [bbsAnswer, setBbsAnswer] = useState<"yes" | "no">(() => savedSession.bbsAnswer ?? "yes");
+  const [bbsModalStep, setBbsModalStep] = useState<"question" | "entry" | null>(
+    null,
+  );
+  const [bbsAnswer, setBbsAnswer] = useState<"yes" | "no">(
+    () => savedSession.bbsAnswer ?? "yes",
+  );
   const [bbsRows, setBbsRows] = useState<BBSRow[]>(
-    () => savedSession.bbsRows ?? [{ id: "1", mark: "", size: "Y16", length: "", quantity: "" }],
+    () =>
+      savedSession.bbsRows ?? [
+        { id: "1", mark: "", size: "Y16", length: "", quantity: "" },
+      ],
   );
   const [showScaleSetup, setShowScaleSetup] = useState(false);
-  const [scaleWhat, setScaleWhat] = useState(() => savedSession.scaleWhat ?? "Pile");
+  const [scaleWhat, setScaleWhat] = useState(
+    () => savedSession.scaleWhat ?? "Piles",
+  );
   const [countModeActive, setCountModeActive] = useState(false);
-  const [showRebarTab, setShowRebarTab] = useState(() => savedSession.showRebarTab ?? false);
+  const [showRebarTab, setShowRebarTab] = useState(
+    () => savedSession.showRebarTab ?? false,
+  );
+
+  // Dual-mode categories (Stud Column / Columns) — which tool the user picked.
+  const [columnMeasureChoice, setColumnMeasureChoice] = useState<
+    "count" | "area" | null
+  >(null);
+  // Which tab of the Element Detail Panel is active — drives whether the canvas
+  // tool is the category's own tool (concrete) or forced to "length" (rebar).
+  const [elementPanelTab, setElementPanelTab] = useState<"concrete" | "rebar">(
+    "concrete",
+  );
+  // Length drawn on canvas while the Rebar tab is active, passed down to auto-fill bar depths.
+  const [rebarDrawnLength, setRebarDrawnLength] = useState<number | null>(null);
 
   // ── Backend-owned state — start empty, populated by Phase 2 hydration ────────
   const [scaleFlowActive, setScaleFlowActive] = useState(false);
@@ -388,12 +468,16 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const [distanceUnit, setDistanceUnit] = useState("Meters");
   const [scaleLocked, setScaleLocked] = useState(false);
   const [scaleInfo, setScaleInfo] = useState<string | null>(null);
-  const [globalScaleFactor, setGlobalScaleFactor] = useState<number | null>(null);
+  const [globalScaleFactor, setGlobalScaleFactor] = useState<number | null>(
+    null,
+  );
   const [showScaleNotification, setShowScaleNotification] = useState(false);
   const scaleNotifTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [showElementPanel, setShowElementPanel] = useState(false);
-  const [concreteMeasurements, setConcreteMeasurements] = useState<WsConcreteMeasurement[]>([]);
+  const [concreteMeasurements, setConcreteMeasurements] = useState<
+    WsConcreteMeasurement[]
+  >([]);
 
   // ── Auto-save ────────────────────────────────────────────────────────────────
   // currentVariantId stays stable for one measurement round. It is the clientId
@@ -401,13 +485,21 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   // Cycling it (on "Apply & Continue") starts a fresh measurement round.
   const currentVariantId = useRef<string>(crypto.randomUUID());
   const lastFormPayload = useRef<SaveMeasurementPayload | null>(null);
-  const [autoSaveStatus, setAutoSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [autoSaveStatus, setAutoSaveStatus] = useState<
+    "idle" | "saving" | "saved"
+  >("idle");
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevMarkCount = useRef(0);
+  // IDs of canvas marks drawn while the Rebar tab was active — excluded from the
+  // concrete variant's own geometry (see handleMeasurementAdd / handleAutoSave).
+  const rebarMarkIds = useRef<Set<string>>(new Set());
 
   // Assign element flow
-  const [assigningElementId, setAssigningElementId] = useState<string | null>(null);
-  const [assigningElement, setAssigningElement] = useState<CreatedElement | null>(null);
+  const [assigningElementId, setAssigningElementId] = useState<string | null>(
+    null,
+  );
+  const [assigningElement, setAssigningElement] =
+    useState<CreatedElement | null>(null);
   const [assignModalOpen, setAssignModalOpen] = useState(false);
   const [confirmAssignOpen, setConfirmAssignOpen] = useState(false);
   const [assignCompleteOpen, setAssignCompleteOpen] = useState(false);
@@ -421,12 +513,41 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   } | null>(null);
 
   // Finalize session for View BOQ
-  const [finalizeSession, { isLoading: finalizing }] = useFinalizeMeasurementSessionMutation();
+  const [finalizeSession, { isLoading: finalizing }] =
+    useFinalizeMeasurementSessionMutation();
   const router = useRouter();
 
   // Sidebar: DRAWINGS collapsible drawer + ELEMENTS panel
-  const [drawingsOpen, setDrawingsOpen] = useState(() => (savedSession.drawings ?? []).length > 0);
+  const [drawingsOpen, setDrawingsOpen] = useState(
+    () => (savedSession.drawings ?? []).length > 0,
+  );
   const [elementSearch, setElementSearch] = useState("");
+
+  // Left workspace sidebar — collapsed by default so the drawing gets full width;
+  // expands to the full Tools/Element/Drawings column when the header icon is clicked.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    () => savedSession.sidebarCollapsed ?? true,
+  );
+
+  // ── Floating Element Detail Panel — draggable + collapsible, position persists ──
+  const [elementPanelPos, setElementPanelPos] = useState<{
+    x: number;
+    y: number;
+  } | null>(() => savedSession.elementPanelPos ?? null);
+  const [elementPanelCollapsed, setElementPanelCollapsed] = useState(
+    () => savedSession.elementPanelCollapsed ?? false,
+  );
+  const canvasAreaRef = useRef<HTMLDivElement>(null);
+  const elementPanelRef = useRef<HTMLDivElement>(null);
+  const panelDragState = useRef<{
+    startX: number;
+    startY: number;
+    origX: number;
+    origY: number;
+    width: number;
+    height: number;
+    moved: boolean;
+  } | null>(null);
   const [expandedCategories, setExpandedCategories] = useState<string[]>([]);
   // Elements — populated by Phase 2 hydration from backend, never from localStorage
   const [elements, setElements] = useState<CreatedElement[]>([]);
@@ -437,18 +558,28 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const [calibPts, setCalibPts] = useState<[MPoint, MPoint] | null>(null);
 
   // Live in-progress length from the canvas (A→cursor, null when not drawing)
-  const [liveDrawingLength, setLiveDrawingLength] = useState<number | null>(null);
+  const [liveDrawingLength, setLiveDrawingLength] = useState<number | null>(
+    null,
+  );
 
   // ── Session totals — accumulate across files until Apply & Continue ───────────
   // Left sidebar  = per-page totals (lengthTotal / countTotal / areaTotal below)
   // Right sidebar = session totals (what you've measured this round across all files)
-  const [sessionTotals, setSessionTotals] = useState({ count: 0, length: 0, area: 0 });
+  const [sessionTotals, setSessionTotals] = useState({
+    count: 0,
+    length: 0,
+    area: 0,
+  });
 
   // ── Per-page measurement state (persisted to localStorage) ───────────────────
-  const measurementHook = useCanvasMeasurements(selectedDrawingId, selectedPage);
+  const measurementHook = useCanvasMeasurements(
+    selectedDrawingId,
+    selectedPage,
+  );
 
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const selectedDrawing = drawings.find((d) => d.id === selectedDrawingId) ?? null;
+  const selectedDrawing =
+    drawings.find((d) => d.id === selectedDrawingId) ?? null;
 
   // ── On mount: wipe stale backend-owned keys from localStorage ───────────────
   // Scale, elements, and variants are now sourced from the backend session.
@@ -467,7 +598,7 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       knownDistance: "",
       elementAssignments: [],
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
   // ── Phase 1: Open/resume a measurement session whenever the drawing+page changes ──
@@ -486,7 +617,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
       // Pause the session we are leaving so the backend frees the "active" slot.
       if (activeSessionId) {
-        await updateSessionStatus({ sessionId: activeSessionId, body: { status: "paused" } });
+        await updateSessionStatus({
+          sessionId: activeSessionId,
+          body: { status: "paused" },
+        });
       }
 
       if (cancelled) return;
@@ -495,7 +629,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
       if (cached) {
         // Already visited this page — just resume the existing session.
-        await updateSessionStatus({ sessionId: cached, body: { status: "active" } });
+        await updateSessionStatus({
+          sessionId: cached,
+          body: { status: "active" },
+        });
         if (!cancelled) setActiveSessionId(cached);
         return;
       }
@@ -503,7 +640,11 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       // First visit to this page — create a fresh session.
       const result = await createMeasurementSession({
         projectId,
-        body: { uploadedFileId, pageNumber: selectedPage, canvas: { width: 1920, height: 1080 } },
+        body: {
+          uploadedFileId,
+          pageNumber: selectedPage,
+          canvas: { width: 1920, height: 1080 },
+        },
       });
 
       if (cancelled) return;
@@ -517,7 +658,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
       // 409 still possible if an active session exists from another device / tab.
       // List sessions to surface the conflict dialog so the user can resolve it.
-      if ("error" in result && (result.error as { status?: number })?.status === 409) {
+      if (
+        "error" in result &&
+        (result.error as { status?: number })?.status === 409
+      ) {
         const sessionsResult = await fetchProjectSessions(projectId);
         if (cancelled) return;
         const list = "data" in sessionsResult ? sessionsResult.data?.data : [];
@@ -538,10 +682,12 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     }
 
     switchSession();
-    return () => { cancelled = true; };
-  // activeSessionId intentionally excluded — including it would cause the effect
-  // to re-run every time a session is set, creating an infinite loop.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      cancelled = true;
+    };
+    // activeSessionId intentionally excluded — including it would cause the effect
+    // to re-run every time a session is set, creating an infinite loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDrawing?.uploadedFileId, selectedPage, projectId]);
 
   // ── Phase 2: Re-hydrate canvas calibration from the active session ───────────
@@ -561,11 +707,14 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       setScaleLocked(true);
       setScaleFlowActive(true);
       setShowElementPanel(true);
-      setScaleInfo(`Scale: 1 px = ${(1 / backendScale).toFixed(3)} ${backendUnit}`);
+      setScaleInfo(
+        `Scale: 1 px = ${(1 / backendScale).toFixed(3)} ${backendUnit}`,
+      );
     }
 
     const calibration = session.canvas.calibration;
-    if (calibration?.knownDistance) setKnownDistance(String(calibration.knownDistance));
+    if (calibration?.knownDistance)
+      setKnownDistance(String(calibration.knownDistance));
     if (calibration?.unit) setDistanceUnit(calibration.unit);
 
     let countIdx = 1;
@@ -579,9 +728,18 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     }
 
     if (measurements.length > 0 || backendScale) {
-      measurementHook.resetWithData({ scaleFactor: backendScale ?? null, calibPts: null, measurements });
+      measurementHook.resetWithData({
+        scaleFactor: backendScale ?? null,
+        calibPts: null,
+        measurements,
+      });
     }
-  }, [activeSessionData, activeSessionId, distanceUnit, measurementHook.resetWithData]);
+  }, [
+    activeSessionData,
+    activeSessionId,
+    distanceUnit,
+    measurementHook.resetWithData,
+  ]);
 
   // ── Global element loader: merge assigned elements from ALL project sessions ──
   // Runs once after the project document loads. Fetches every session in parallel
@@ -595,10 +753,13 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
     async function loadAllElements() {
       const sessionsResult = await fetchProjectSessions(projectId);
-      if (!("data" in sessionsResult) || !sessionsResult.data?.data?.length) return;
+      if (!("data" in sessionsResult) || !sessionsResult.data?.data?.length)
+        return;
 
       const sessionIds = sessionsResult.data.data.map((s) => s._id);
-      const sessionResults = await Promise.all(sessionIds.map((id) => fetchSessionById(id)));
+      const sessionResults = await Promise.all(
+        sessionIds.map((id) => fetchSessionById(id)),
+      );
 
       const assignedElementMap = new Map<
         string,
@@ -617,7 +778,11 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
           if (!snapshotStr) continue;
 
           let parsedVariant: WsConcreteMeasurement | null = null;
-          try { parsedVariant = JSON.parse(snapshotStr) as WsConcreteMeasurement; } catch { continue; }
+          try {
+            parsedVariant = JSON.parse(snapshotStr) as WsConcreteMeasurement;
+          } catch {
+            continue;
+          }
 
           if (attrs.pending === true) {
             if (!pendingVariantsMap.has(parsedVariant.id)) {
@@ -634,7 +799,8 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
                   id: eid,
                   name: elementName,
                   category: (attrs.elementCategory as string) ?? "Substructure",
-                  categoryFolder: (attrs.categoryFolder as string) ?? elementName,
+                  categoryFolder:
+                    (attrs.categoryFolder as string) ?? elementName,
                   measurementUnit: (attrs.measurementUnit as string) ?? "items",
                   variants: [],
                   sessionId: sid,
@@ -656,7 +822,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
       const reconstructedElements: CreatedElement[] = Array.from(
         assignedElementMap.values(),
-      ).map(({ meta, variantMap }) => ({ ...meta, variants: Array.from(variantMap.values()) }));
+      ).map(({ meta, variantMap }) => ({
+        ...meta,
+        variants: Array.from(variantMap.values()),
+      }));
 
       const reconstructedPending = Array.from(pendingVariantsMap.values());
 
@@ -677,8 +846,8 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     }
 
     loadAllElements();
-  // fetchProjectSessions and fetchSessionById are stable references from RTK Query lazy hooks
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // fetchProjectSessions and fetchSessionById are stable references from RTK Query lazy hooks
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backendProject?._id, projectId]);
 
   // ── Auto-save: upsert the current variant to the backend ─────────────────────
@@ -690,10 +859,11 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     const payload = formPayload ?? lastFormPayload.current;
     if (formPayload) lastFormPayload.current = formPayload;
 
-    const measurementIds = measurementHook.state.measurements.map((m) => m.id);
-    const tool: "count" | "length" | "area" =
-      activeTool === "count" ? "count" : activeTool === "area" ? "area" : "length";
-
+    // Rebar-tab marks are reference lengths for bar depth, not part of the
+    // element's own concrete geometry — exclude them from this variant's canvas.
+    const measurementIds = measurementHook.state.measurements
+      .map((m) => m.id)
+      .filter((id) => !rebarMarkIds.current.has(id));
     const variant: WsConcreteMeasurement = {
       id: currentVariantId.current,
       measureType: scaleWhat,
@@ -701,9 +871,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       concreteFields: payload?.concreteFields ?? {},
       rebar: payload?.rebar ?? null,
       canvas: {
-        tool,
+        tool: concreteToolForCategory,
         count: sessionTotals.count,
-        length: sessionTotals.length + (liveDrawingLength ?? 0),
+        length: effectiveConcreteLength,
         area: sessionTotals.area,
         unit: distanceUnit,
         measurementIds,
@@ -717,7 +887,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setConcreteMeasurements((prev) => {
       const idx = prev.findIndex((v) => v.id === currentVariantId.current);
       const next =
-        idx >= 0 ? prev.map((v, i) => (i === idx ? variant : v)) : [...prev, variant];
+        idx >= 0
+          ? prev.map((v, i) => (i === idx ? variant : v))
+          : [...prev, variant];
       saveSession(projectId, { concreteMeasurements: next });
       return next;
     });
@@ -728,13 +900,18 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     autoSaveTimerRef.current = setTimeout(() => {
       setAutoSaveStatus("saved");
-      autoSaveTimerRef.current = setTimeout(() => setAutoSaveStatus("idle"), 3000);
+      autoSaveTimerRef.current = setTimeout(
+        () => setAutoSaveStatus("idle"),
+        3000,
+      );
     }, 400);
   }
 
   // Keep a stable ref so the canvas mark effect never captures a stale closure.
   const handleAutoSaveRef = useRef(handleAutoSave);
-  useEffect(() => { handleAutoSaveRef.current = handleAutoSave; });
+  useEffect(() => {
+    handleAutoSaveRef.current = handleAutoSave;
+  });
 
   // Trigger auto-save whenever a new canvas mark is added.
   useEffect(() => {
@@ -743,7 +920,7 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       handleAutoSaveRef.current();
     }
     prevMarkCount.current = count;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [measurementHook.state.measurements.length]);
 
   // ── Keyboard shortcuts: Cmd/Ctrl+Z = undo, Cmd/Ctrl+Shift+Z or Ctrl+Y = redo ──
@@ -751,18 +928,151 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     function onKey(e: KeyboardEvent) {
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
-      if (e.key === "z" && !e.shiftKey) { e.preventDefault(); measurementHook.undo(); }
-      if ((e.key === "z" && e.shiftKey) || e.key === "y") { e.preventDefault(); measurementHook.redo(); }
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        measurementHook.undo();
+      }
+      if ((e.key === "z" && e.shiftKey) || e.key === "y") {
+        e.preventDefault();
+        measurementHook.redo();
+      }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [measurementHook.undo, measurementHook.redo]);
 
+  // Concrete-tab length total, gated so an in-progress rebar-tab drag never leaks
+  // in, with the Lintel +300mm bearing allowance applied once anything is measured.
+  const effectiveConcreteLength = useMemo(() => {
+    const raw =
+      sessionTotals.length +
+      (elementPanelTab === "concrete" ? (liveDrawingLength ?? 0) : 0);
+    return scaleWhat === "Lintel" && raw > 0
+      ? raw + LINTEL_LENGTH_BONUS_M
+      : raw;
+  }, [sessionTotals.length, liveDrawingLength, scaleWhat, elementPanelTab]);
+
+  // ── Category → tool mapping ───────────────────────────────────────────────────
+  // The active category (scaleWhat) decides which canvas tool is used for the
+  // concrete measurement. "choice" categories (Stud Column / Columns) resolve via
+  // columnMeasureChoice, set by the ScaleSetupModal sub-selector.
+  const concreteToolForCategory: "count" | "length" | "area" = useMemo(() => {
+    const cfg = ELEMENT_CONFIGS[scaleWhat] ?? ELEMENT_CONFIGS["Piles"];
+    if (cfg.tool === "choice") return columnMeasureChoice ?? "count";
+    return cfg.tool;
+  }, [scaleWhat, columnMeasureChoice]);
+
+  // While the Rebar tab is active, the canvas always draws lengths (rebar runs),
+  // regardless of what tool the concrete measurement uses. Switching back to the
+  // Concrete tab restores the category's own tool.
+  useEffect(() => {
+    if (!scaleFlowActive) return;
+    if (elementPanelTab === "rebar") {
+      setActiveTool("length");
+      setCountModeActive(false);
+    } else {
+      setActiveTool(concreteToolForCategory);
+      setCountModeActive(concreteToolForCategory === "count");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [elementPanelTab, concreteToolForCategory, scaleFlowActive]);
+
+  function handleElementPanelTabChange(tab: "concrete" | "rebar") {
+    setElementPanelTab(tab);
+    if (tab === "concrete") setRebarDrawnLength(null);
+  }
+
+  function handleAddNewElement() {
+    // Start a fresh measurement round so this doesn't overwrite whatever variant
+    // was previously being drawn.
+    currentVariantId.current = crypto.randomUUID();
+    lastFormPayload.current = null;
+    setColumnMeasureChoice(null);
+    setElementPanelTab("concrete");
+    setRebarDrawnLength(null);
+    setSessionTotals({ count: 0, length: 0, area: 0 });
+    setLiveDrawingLength(null);
+    setPendingTool(null);
+    setBbsModalStep("question");
+  }
+
+  // ── Floating Element Detail Panel: drag + collapse ────────────────────────────
+
+  function handlePanelDragStart(e: React.PointerEvent<HTMLElement>) {
+    const container = canvasAreaRef.current;
+    const panelEl = elementPanelRef.current;
+    if (!container || !panelEl) return;
+    const containerRect = container.getBoundingClientRect();
+    const panelRect = panelEl.getBoundingClientRect();
+    panelDragState.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      origX: elementPanelPos?.x ?? panelRect.left - containerRect.left,
+      origY: elementPanelPos?.y ?? panelRect.top - containerRect.top,
+      width: panelRect.width,
+      height: panelRect.height,
+      moved: false,
+    };
+    (e.target as Element).setPointerCapture(e.pointerId);
+  }
+
+  function handlePanelDragMove(e: React.PointerEvent<HTMLElement>) {
+    const ds = panelDragState.current;
+    const container = canvasAreaRef.current;
+    if (!ds || !container) return;
+    const dx = e.clientX - ds.startX;
+    const dy = e.clientY - ds.startY;
+    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) ds.moved = true;
+    if (!ds.moved) return;
+    const rect = container.getBoundingClientRect();
+    const nextX = Math.min(
+      Math.max(ds.origX + dx, 0),
+      Math.max(rect.width - ds.width, 0),
+    );
+    const nextY = Math.min(
+      Math.max(ds.origY + dy, 0),
+      Math.max(rect.height - ds.height, 0),
+    );
+    setElementPanelPos({ x: nextX, y: nextY });
+  }
+
+  function handlePanelDragEnd() {
+    const ds = panelDragState.current;
+    panelDragState.current = null;
+    if (!ds?.moved) return;
+    setElementPanelPos((pos) => {
+      if (pos) saveSession(projectId, { elementPanelPos: pos });
+      return pos;
+    });
+  }
+
+  function handlePanelToggleCollapsed() {
+    // Ignore the click that follows a real drag (pointerup fires a click too).
+    if (panelDragState.current?.moved) return;
+    setElementPanelCollapsed((prev) => {
+      const next = !prev;
+      saveSession(projectId, { elementPanelCollapsed: next });
+      return next;
+    });
+  }
+
   // ── Tool click ───────────────────────────────────────────────────────────────
 
   function handleToolClick(id: ToolId) {
-    if (id === "undo") { measurementHook.undo(); return; }
-    if (id === "redo") { measurementHook.redo(); return; }
+    if (id === "undo") {
+      measurementHook.undo();
+      return;
+    }
+    if (id === "redo") {
+      measurementHook.redo();
+      return;
+    }
+    // Text is a plain annotation tool, not a measurable BOQ category — it never
+    // goes through the BBS/Scale modal chain (that's only for "+ New Element").
+    if (id === "text") {
+      setActiveTool((prev) => (prev === "text" ? null : "text"));
+      return;
+    }
     // Scale already configured — activate tool directly, skip BBS/Scale modal chain.
     // This lets the user navigate to another page for additional rebar/concrete
     // measurements without being re-prompted for BBS or scale every time.
@@ -778,11 +1088,15 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   function handleScaleSetupMeasureChange(value: string) {
     setScaleWhat(value);
+    setColumnMeasureChoice(null);
   }
 
   // ── BBS question ─────────────────────────────────────────────────────────────
 
-  function handleBBSClose() { setBbsModalStep(null); setPendingTool(null); }
+  function handleBBSClose() {
+    setBbsModalStep(null);
+    setPendingTool(null);
+  }
   function handleBBSSkip() {
     setShowRebarTab(false);
     saveSession(projectId, { bbsAnswer, showRebarTab: false });
@@ -803,7 +1117,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   // ── BBS entry ────────────────────────────────────────────────────────────────
 
-  function handleBBSEntryCancel() { setBbsModalStep(null); setPendingTool(null); }
+  function handleBBSEntryCancel() {
+    setBbsModalStep(null);
+    setPendingTool(null);
+  }
   function handleBBSSave() {
     console.log("[CountTool] BBS saved:", bbsRows);
     toast.success("Bar Bending Schedule saved");
@@ -813,10 +1130,21 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setShowScaleSetup(true);
   }
   function handleBBSRowChange(id: string, field: keyof BBSRow, value: string) {
-    setBbsRows((rows) => rows.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+    setBbsRows((rows) =>
+      rows.map((r) => (r.id === id ? { ...r, [field]: value } : r)),
+    );
   }
   function handleAddBBSRow() {
-    setBbsRows((rows) => [...rows, { id: crypto.randomUUID(), mark: "", size: "Y16", length: "", quantity: "" }]);
+    setBbsRows((rows) => [
+      ...rows,
+      {
+        id: crypto.randomUUID(),
+        mark: "",
+        size: "Y16",
+        length: "",
+        quantity: "",
+      },
+    ]);
   }
 
   // ── Scale setup ──────────────────────────────────────────────────────────────
@@ -825,19 +1153,61 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setShowScaleSetup(false);
     setScaleFlowActive(true);
     setShowElementPanel(true);
+    setPendingTool(null);
+    // Next step of the "+ New Element" flow — same modal as the sidebar's
+    // "Create Elements" button, so the element is real and shows up there too.
+    setCreateNewElOpen(true);
 
-    // Activate the tool button immediately after modal so the user sees the tool is selected.
-    // Canvas drawing is still blocked: clicks are either calibration-mode (red reference dots)
-    // or fully gated by the scaleFactor=null guard until Apply Scale is clicked.
-    if (pendingTool) {
-      setActiveTool(pendingTool);
-      if (pendingTool === "count") setCountModeActive(true);
-      setPendingTool(null);
+    // Activate the tool derived from the chosen category immediately, so the user
+    // sees the right tool selected. Canvas drawing is still blocked: clicks are
+    // either calibration-mode (red reference dots) or fully gated by the
+    // scaleFactor=null guard until Apply Scale is clicked.
+    setActiveTool(concreteToolForCategory);
+    setCountModeActive(concreteToolForCategory === "count");
+
+    // Bar Bending Schedule already known for this element — seed it as the rebar
+    // payload on the zero-measurement element created below, instead of nulls.
+    if (
+      bbsAnswer === "yes" &&
+      bbsRows.some((r) => r.mark || r.size !== "Y16" || r.length || r.quantity)
+    ) {
+      lastFormPayload.current = {
+        tag: "",
+        concreteFields: {},
+        rebar: {
+          method: "manual",
+          mainBars: bbsRows.map((r) => ({
+            id: r.id,
+            size: r.size,
+            count: r.quantity,
+            depth: r.length,
+          })),
+          additionBars: [],
+          includeStirups: false,
+          stirrupSize: "Y8",
+          stirrupSpacing: "0",
+        },
+        canvas: {
+          tool: concreteToolForCategory,
+          count: 0,
+          length: 0,
+          area: 0,
+          unit: distanceUnit,
+        },
+      };
     }
+
+    // Create the element on the backend right away with a zero-value measurement —
+    // drawing on the canvas afterward upserts this same variant via auto-save.
+    setTimeout(() => handleAutoSaveRef.current(), 0);
 
     if (scaleLocked && globalScaleFactor !== null) {
       // Scale already applied and locked — jump straight to measuring, no re-calibration
-      saveSession(projectId, { scaleWhat, scaleFlowActive: true, scaleLocked: true });
+      saveSession(projectId, {
+        scaleWhat,
+        scaleFlowActive: true,
+        scaleLocked: true,
+      });
     } else {
       // Scale not yet applied — show calibration bar, canvas accepts 2 reference clicks
       setCalibPtCount(0);
@@ -846,17 +1216,25 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       saveSession(projectId, { scaleWhat, scaleFlowActive: true });
     }
   }
-  function handleScaleSetupCancel() { setShowScaleSetup(false); setPendingTool(null); }
+  function handleScaleSetupCancel() {
+    setShowScaleSetup(false);
+    setPendingTool(null);
+  }
 
   // ── Calibration ──────────────────────────────────────────────────────────────
 
-  function handleApplyScale() {
+  // Scale only takes effect locally once the backend confirms it — this is what
+  // actually gates drawing (via isCalibrating in MeasurementCanvas), so a failed
+  // save must never leave the app acting as if scale was applied.
+  async function handleApplyScale() {
     if (!knownDistance) {
       toast.warning("Enter a known distance first");
       return;
     }
     if (!calibBasePxDist || !calibPts) {
-      toast.warning("Click two points on the drawing to define the reference distance");
+      toast.warning(
+        "Click two points on the drawing to define the reference distance",
+      );
       return;
     }
     const realDist = parseFloat(knownDistance);
@@ -864,9 +1242,32 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       toast.warning("Enter a valid distance greater than 0");
       return;
     }
+    if (!activeSessionId) {
+      toast.error("No active session — reopen the page and try again.");
+      return;
+    }
 
     // scaleFactor = base pixels per real unit
     const sf = calibBasePxDist / realDist;
+
+    try {
+      await updateMeasurementCanvas({
+        sessionId: activeSessionId,
+        body: {
+          calibration: {
+            knownDistance: realDist,
+            pixelDistance: calibBasePxDist,
+            unit: distanceUnit,
+          },
+        },
+      }).unwrap();
+    } catch {
+      toast.error(
+        "Could not save the scale — check your connection and try again.",
+      );
+      return;
+    }
+
     setGlobalScaleFactor(sf);
     measurementHook.setCalibration(calibPts, sf);
 
@@ -875,7 +1276,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setScaleInfo(newScaleInfo);
     setShowScaleNotification(true);
     if (scaleNotifTimerRef.current) clearTimeout(scaleNotifTimerRef.current);
-    scaleNotifTimerRef.current = setTimeout(() => setShowScaleNotification(false), 5000);
+    scaleNotifTimerRef.current = setTimeout(
+      () => setShowScaleNotification(false),
+      5000,
+    );
     saveSession(projectId, {
       knownDistance,
       distanceUnit,
@@ -885,16 +1289,6 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       scaleLocked: false,
       scaleFactor: sf,
     });
-
-    // Phase 3: persist calibration to backend
-    if (activeSessionId) {
-      updateMeasurementCanvas({
-        sessionId: activeSessionId,
-        body: {
-          calibration: { knownDistance: realDist, pixelDistance: calibBasePxDist, unit: distanceUnit },
-        },
-      });
-    }
   }
 
   function handleResetScale() {
@@ -912,11 +1306,22 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setCalibPtCount(0);
     setCalibBasePxDist(null);
     setCalibPts(null);
-    saveSession(projectId, { scaleInfo: null, knownDistance: "", scaleLocked: false, scaleFlowActive: false, scaleFactor: null });
+    setColumnMeasureChoice(null);
+    setElementPanelTab("concrete");
+    setRebarDrawnLength(null);
+    saveSession(projectId, {
+      scaleInfo: null,
+      knownDistance: "",
+      scaleLocked: false,
+      scaleFlowActive: false,
+      scaleFactor: null,
+    });
   }
 
   function handleSaveMeasurement(payload: SaveMeasurementPayload) {
-    const measurementIds = measurementHook.state.measurements.map((m) => m.id);
+    const measurementIds = measurementHook.state.measurements
+      .map((m) => m.id)
+      .filter((id) => !rebarMarkIds.current.has(id));
 
     // Use currentVariantId so "Apply & Continue" finalises whatever auto-save
     // already persisted, rather than creating a duplicate with a new UUID.
@@ -936,7 +1341,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setConcreteMeasurements((prev) => {
       const idx = prev.findIndex((v) => v.id === currentVariantId.current);
       const next =
-        idx >= 0 ? prev.map((v, i) => (i === idx ? variant : v)) : [...prev, variant];
+        idx >= 0
+          ? prev.map((v, i) => (i === idx ? variant : v))
+          : [...prev, variant];
       saveSession(projectId, { concreteMeasurements: next });
       return next;
     });
@@ -980,8 +1387,13 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       concreteMeasurements[0]?.canvas.tool === "count"
         ? concreteMeasurements.reduce((s, v) => s + v.canvas.count, 0)
         : concreteMeasurements[0]?.canvas.tool === "length"
-          ? Math.round(concreteMeasurements.reduce((s, v) => s + v.canvas.length, 0) * 100) / 100
-          : Math.round(concreteMeasurements.reduce((s, v) => s + v.canvas.area, 0) * 100) / 100;
+          ? Math.round(
+              concreteMeasurements.reduce((s, v) => s + v.canvas.length, 0) *
+                100,
+            ) / 100
+          : Math.round(
+              concreteMeasurements.reduce((s, v) => s + v.canvas.area, 0) * 100,
+            ) / 100;
 
     const addedUnit =
       concreteMeasurements[0]?.canvas.tool === "count"
@@ -994,7 +1406,14 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
     const newTotal = updatedElement.variants.reduce((s, v) => {
       const tool = v.canvas.tool;
-      return s + (tool === "count" ? v.canvas.count : tool === "length" ? v.canvas.length : v.canvas.area);
+      return (
+        s +
+        (tool === "count"
+          ? v.canvas.count
+          : tool === "length"
+            ? v.canvas.length
+            : v.canvas.area)
+      );
     }, 0);
 
     setElements(updatedElements);
@@ -1007,7 +1426,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       assignedAt: Date.now(),
     };
     const prevAssignments = loadSession(projectId).elementAssignments ?? [];
-    saveSession(projectId, { elementAssignments: [...prevAssignments, assignment] });
+    saveSession(projectId, {
+      elementAssignments: [...prevAssignments, assignment],
+    });
 
     // Persist all variant geometry + data to the backend now that they're assigned.
     // Pass element metadata so the backend can return it on hydration and we can
@@ -1039,7 +1460,11 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setAssignCompleteOpen(true);
   }
 
-  function handleCreateNewEl(data: { categoryFolder: string; measurementUnit: string; rows: PileRow[] }) {
+  function handleCreateNewEl(data: {
+    categoryFolder: string;
+    measurementUnit: string;
+    rows: PileRow[];
+  }) {
     const parts = data.categoryFolder.split(" / ");
     const category = parts[0] ?? "Substructure";
     const name = parts.slice(1).join(" / ") || "Element";
@@ -1087,8 +1512,13 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       concreteMeasurements[0]?.canvas.tool === "count"
         ? concreteMeasurements.reduce((s, v) => s + v.canvas.count, 0)
         : concreteMeasurements[0]?.canvas.tool === "length"
-          ? Math.round(concreteMeasurements.reduce((s, v) => s + v.canvas.length, 0) * 100) / 100
-          : Math.round(concreteMeasurements.reduce((s, v) => s + v.canvas.area, 0) * 100) / 100;
+          ? Math.round(
+              concreteMeasurements.reduce((s, v) => s + v.canvas.length, 0) *
+                100,
+            ) / 100
+          : Math.round(
+              concreteMeasurements.reduce((s, v) => s + v.canvas.area, 0) * 100,
+            ) / 100;
 
     const addedUnit =
       concreteMeasurements[0]?.canvas.tool === "count"
@@ -1126,11 +1556,16 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   async function handleViewBoq() {
     if (!activeSessionId) {
-      toast.warning("No active session — open a drawing page first before viewing the BOQ.");
+      toast.warning(
+        "No active session — open a drawing page first before viewing the BOQ.",
+      );
       return;
     }
     try {
-      await finalizeSession({ sessionId: activeSessionId, body: { commit: true } }).unwrap();
+      await finalizeSession({
+        sessionId: activeSessionId,
+        body: { commit: true },
+      }).unwrap();
       router.push(`${basePath}/${projectId}/boq`);
     } catch (err: unknown) {
       const status = (err as { status?: number })?.status;
@@ -1149,7 +1584,7 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   function handleCalibrationUpdate(
     basePxDist: number | null,
     pts: [MPoint, MPoint] | null,
-    ptCount: 0 | 1 | 2
+    ptCount: 0 | 1 | 2,
   ) {
     setCalibBasePxDist(basePxDist);
     setCalibPts(pts);
@@ -1162,10 +1597,22 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   function handleMeasurementAdd(m: Measurement) {
     measurementHook.addMeasurement(m);
+
+    // Rebar tab: the drawn length fills bar depths in the panel instead of
+    // contributing to this element's own concrete quantity.
+    if (elementPanelTab === "rebar" && m.type === "length") {
+      rebarMarkIds.current.add(m.id);
+      setRebarDrawnLength(m.realLength);
+      return;
+    }
+
     if (m.type === "count") {
       setSessionTotals((prev) => ({ ...prev, count: prev.count + 1 }));
     } else if (m.type === "length") {
-      setSessionTotals((prev) => ({ ...prev, length: prev.length + m.realLength }));
+      setSessionTotals((prev) => ({
+        ...prev,
+        length: prev.length + m.realLength,
+      }));
     } else if (m.type === "area") {
       setSessionTotals((prev) => ({ ...prev, area: prev.area + m.realArea }));
     }
@@ -1208,7 +1655,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       // Snapshot is stored on every backend element so the hydration pass can
       // reconstruct WsConcreteMeasurement objects without touching localStorage.
       // measurementIds are canvas-local and meaningless after a page reload, so exclude them.
-      const _snapshot = JSON.stringify({ ...variant, canvas: { ...variant.canvas, measurementIds: [] } });
+      const _snapshot = JSON.stringify({
+        ...variant,
+        canvas: { ...variant.canvas, measurementIds: [] },
+      });
 
       const sharedAttrs: Record<string, unknown> = {
         elementId,
@@ -1272,14 +1722,20 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   // ── Upsert a single variant to the backend immediately on "Apply & Continue" ──
   // Uses variant.id as clientId so it is idempotent and cleanly overwritten
   // (count) or deleted (length/area) when the element is later assigned.
-  function upsertPendingVariant(variant: WsConcreteMeasurement, sessionId: string) {
+  function upsertPendingVariant(
+    variant: WsConcreteMeasurement,
+    sessionId: string,
+  ) {
     const allMeasurements = measurementHook.state.measurements;
     const variantMarks = allMeasurements.filter((m) =>
       variant.canvas.measurementIds.includes(m.id),
     );
     const backendType = toBackendElementType(variant.measureType);
     const color = variantMarks[0]?.color ?? "#f59e0b";
-    const _snapshot = JSON.stringify({ ...variant, canvas: { ...variant.canvas, measurementIds: [] } });
+    const _snapshot = JSON.stringify({
+      ...variant,
+      canvas: { ...variant.canvas, measurementIds: [] },
+    });
     const pendingAttrs: Record<string, unknown> = {
       pending: true,
       measureType: variant.measureType,
@@ -1332,7 +1788,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     const { liveSessionId, uploadedFileId, pageNumber } = sessionConflict;
     setActiveSessionId(liveSessionId);
     if (uploadedFileId) {
-      openedSessionKeys.current.set(`${uploadedFileId}-${pageNumber ?? 1}`, liveSessionId);
+      openedSessionKeys.current.set(
+        `${uploadedFileId}-${pageNumber ?? 1}`,
+        liveSessionId,
+      );
       const drawing = drawings.find((d) => d.uploadedFileId === uploadedFileId);
       if (drawing) {
         setSelectedDrawingId(drawing.id);
@@ -1352,7 +1811,11 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       setSessionConflict(null);
       const result = await createMeasurementSession({
         projectId,
-        body: { uploadedFileId, pageNumber: selectedPage, canvas: { width: 1920, height: 1080 } },
+        body: {
+          uploadedFileId,
+          pageNumber: selectedPage,
+          canvas: { width: 1920, height: 1080 },
+        },
       });
       if ("data" in result && result.data?.data?._id) {
         const sid = result.data.data._id;
@@ -1370,6 +1833,8 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   function handleSessionReset() {
     setSessionTotals({ count: 0, length: 0, area: 0 });
     setLiveDrawingLength(null);
+    setRebarDrawnLength(null);
+    setElementPanelTab("concrete");
   }
 
   // ── Per-page totals for the LEFT sidebar stat bar ─────────────────────────────
@@ -1377,7 +1842,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const { countTotal, lengthTotal, areaTotal } = useMemo(() => {
     const ms = measurementHook.state.measurements;
     const sf = globalScaleFactor;
-    let countTotal = 0, lengthTotal = 0, areaTotal = 0;
+    let countTotal = 0,
+      lengthTotal = 0,
+      areaTotal = 0;
     for (const m of ms) {
       if (m.type === "count") countTotal++;
       else if (m.type === "length" && sf) lengthTotal += m.pixelLength / sf;
@@ -1387,8 +1854,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   }, [measurementHook.state.measurements, globalScaleFactor]);
 
   const nextCountIndex = useMemo(
-    () => measurementHook.state.measurements.filter((m) => m.type === "count").length + 1,
-    [measurementHook.state.measurements]
+    () =>
+      measurementHook.state.measurements.filter((m) => m.type === "count")
+        .length + 1,
+    [measurementHook.state.measurements],
   );
 
   // ── Canvas helpers ────────────────────────────────────────────────────────────
@@ -1397,6 +1866,23 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
   const zoomOut = () => setScale((s) => Math.max(+(s - 0.25).toFixed(2), 0.25));
   const resetZoom = () => setScale(1.0);
 
+  // Mouse wheel and trackpad pinch (browsers report pinch as wheel + ctrlKey) both zoom.
+  function handleCanvasWheel(e: React.WheelEvent<HTMLDivElement>) {
+    e.preventDefault();
+    setScale((s) => {
+      const next = e.deltaY > 0 ? s - 0.1 : s + 0.1;
+      return Math.min(Math.max(+next.toFixed(2), 0.25), 3);
+    });
+  }
+
+  function handleSidebarToggle() {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      saveSession(projectId, { sidebarCollapsed: next });
+      return next;
+    });
+  }
+
   function handleSelectFile(fileId: string) {
     if (selectedDrawingId === fileId) return;
     setSelectedDrawingId(fileId);
@@ -1404,7 +1890,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
     setScale(1.0);
   }
   function handleSelectPage(fileId: string, pageNum: number) {
-    if (selectedDrawingId !== fileId) { setSelectedDrawingId(fileId); setScale(1.0); }
+    if (selectedDrawingId !== fileId) {
+      setSelectedDrawingId(fileId);
+      setScale(1.0);
+    }
     setSelectedPage(pageNum);
   }
 
@@ -1415,7 +1904,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       dispatch(
         setDrawingPages({
           id,
-          pages: Array.from({ length: numPages }, (_, i) => ({ number: i + 1, label: `Page ${i + 1}` })),
+          pages: Array.from({ length: numPages }, (_, i) => ({
+            number: i + 1,
+            label: `Page ${i + 1}`,
+          })),
         }),
       );
     },
@@ -1441,8 +1933,23 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       const category = EXT_CATEGORY[ext] ?? "pdf";
       const id = crypto.randomUUID();
       if (!firstNewId) firstNewId = id;
-      const previewUrl = category === "pdf" || category === "image" ? URL.createObjectURL(file) : undefined;
-      dispatch(addDrawing({ id, name: file.name, size: file.size, extension: ext, category, status: "uploading", progress: 0, previewUrl, folderId: targetFolderId }));
+      const previewUrl =
+        category === "pdf" || category === "image"
+          ? URL.createObjectURL(file)
+          : undefined;
+      dispatch(
+        addDrawing({
+          id,
+          name: file.name,
+          size: file.size,
+          extension: ext,
+          category,
+          status: "uploading",
+          progress: 0,
+          previewUrl,
+          folderId: targetFolderId,
+        }),
+      );
 
       try {
         const formData = new FormData();
@@ -1453,7 +1960,10 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
           onUploadProgress: (event) => {
             if (event.total) {
               const pct = Math.round((event.loaded / event.total) * 100);
-              dispatch({ type: "manualWizard/updateDrawing", payload: { id, progress: pct, status: "uploading" } });
+              dispatch({
+                type: "manualWizard/updateDrawing",
+                payload: { id, progress: pct, status: "uploading" },
+              });
             }
           },
         }).unwrap();
@@ -1461,37 +1971,65 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
         const uploadedFileId = result.data._id;
         const uploadedUrl = result.data.url;
 
-        dispatch({ type: "manualWizard/updateDrawing", payload: { id, status: "processing", progress: 100 } });
+        dispatch({
+          type: "manualWizard/updateDrawing",
+          payload: { id, status: "processing", progress: 100 },
+        });
         await new Promise((r) => setTimeout(r, 400));
-        dispatch({ type: "manualWizard/updateDrawing", payload: { id, status: "complete", uploadedFileId, uploadedUrl } });
+        dispatch({
+          type: "manualWizard/updateDrawing",
+          payload: { id, status: "complete", uploadedFileId, uploadedUrl },
+        });
 
         // Persist drawing to workspace session so it survives a page reload
         const currentSession = loadSession(projectId);
         const sessionDrawings = currentSession.drawings ?? [];
         if (!sessionDrawings.some((d) => d.id === uploadedFileId)) {
           saveSession(projectId, {
-            drawings: [...sessionDrawings, { id: uploadedFileId, name: file.name, url: uploadedUrl, extension: ext, size: file.size }],
+            drawings: [
+              ...sessionDrawings,
+              {
+                id: uploadedFileId,
+                name: file.name,
+                url: uploadedUrl,
+                extension: ext,
+                size: file.size,
+              },
+            ],
           });
         }
 
         // Append new file ID to project's drawings array on the backend
         const existingIds = backendProject?.drawings ?? [];
-        await updateProject({ projectId, body: { drawings: [...existingIds, uploadedFileId] } });
+        await updateProject({
+          projectId,
+          body: { drawings: [...existingIds, uploadedFileId] },
+        });
 
         toast.success(`"${file.name}" uploaded`);
       } catch {
-        dispatch({ type: "manualWizard/updateDrawing", payload: { id, status: "error", error: "Upload failed" } });
+        dispatch({
+          type: "manualWizard/updateDrawing",
+          payload: { id, status: "error", error: "Upload failed" },
+        });
         toast.error(`Failed to upload "${file.name}"`);
       }
     }
 
-    if (firstNewId) { setSelectedDrawingId(firstNewId); setSelectedPage(1); setScale(1.0); }
+    if (firstNewId) {
+      setSelectedDrawingId(firstNewId);
+      setSelectedPage(1);
+      setScale(1.0);
+    }
   }
 
   function getFilesForFolder(folder: DrawingFolder) {
     return folder.fileIds
       .map((id) => drawings.find((d) => d.id === id))
-      .filter((d): d is DrawingFile => !!d && d.name.toLowerCase().includes(search.toLowerCase()));
+      .filter(
+        (d): d is DrawingFile =>
+          !!d && d.name.toLowerCase().includes(search.toLowerCase()),
+      );
   }
 
   function toggleCategory(cat: string) {
@@ -1508,7 +2046,9 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
       )
     : elements;
 
-  const elementsByCategory = filteredElements.reduce<Record<string, CreatedElement[]>>((acc, el) => {
+  const elementsByCategory = filteredElements.reduce<
+    Record<string, CreatedElement[]>
+  >((acc, el) => {
     if (!acc[el.category]) acc[el.category] = [];
     acc[el.category].push(el);
     return acc;
@@ -1516,9 +2056,15 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
 
   const breadcrumb = [
     { label: "Workspace" },
-    ...(selectedDrawing ? [{ label: selectedDrawing.name.replace(/\.[^.]+$/, "") }] : []),
+    ...(selectedDrawing
+      ? [{ label: selectedDrawing.name.replace(/\.[^.]+$/, "") }]
+      : []),
     ...(selectedDrawing && selectedPage > 0
-      ? [{ label: `Page ${selectedPage}${selectedDrawing.pageCount ? ` of ${selectedDrawing.pageCount}` : ""}` }]
+      ? [
+          {
+            label: `Page ${selectedPage}${selectedDrawing.pageCount ? ` of ${selectedDrawing.pageCount}` : ""}`,
+          },
+        ]
       : []),
   ];
 
@@ -1552,705 +2098,979 @@ export function ProjectWorkspaceView({ projectId, basePath }: ProjectWorkspaceVi
           onLoaded={handleDrawingHydrated}
         />
       ))}
-    <div className="flex h-screen overflow-hidden bg-[#e8edf2]">
-      {/* ── Left sidebar ── */}
-      <aside className="w-[248px] shrink-0 bg-white border-r border-slate-100 flex flex-col overflow-hidden">
-        {/* Header */}
-        <div className="px-3 py-3 bg-[#fdf8f0] border-b border-amber-100/60 flex items-center gap-2.5">
-          <div className="w-9 h-9 rounded-xl bg-amber-500 flex items-center justify-center shrink-0 shadow-sm">
-            <LayoutGrid className="w-4.5 h-4.5 text-white" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-[12px] font-bold text-slate-800 leading-snug">QSCalc Pro Workspace</p>
-            <p className="text-[10px] text-slate-500 truncate">{projectName}</p>
-          </div>
-        </div>
-
-        {/* Dashboard */}
-        <div className="px-3 py-1 border-b border-slate-100">
-          <a
-            href={basePath.startsWith("/enterprise") ? "/enterprise/dashboard" : "/dashboard"}
-            className="flex items-center gap-3 px-2 py-2.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors"
-          >
-            <Home className="w-4 h-4 shrink-0" />
-            <span className="text-[11px] font-bold uppercase tracking-widest">Dashboard</span>
-          </a>
-        </div>
-
-        {/* Tools */}
-        <div className="px-3 pt-3 pb-2.5 border-b border-slate-100">
-          <div className="flex items-center gap-1.5 mb-2.5">
-            <Wrench className="w-3.5 h-3.5 text-slate-400" />
-            <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Tools</span>
-          </div>
-          <TooltipProvider delayDuration={400}>
-            <div className="flex gap-1.5">
-              {TOOLS.map((tool) => {
-                const isDisabled =
-                  (tool.id === "undo" && !measurementHook.canUndo) ||
-                  (tool.id === "redo" && !measurementHook.canRedo);
-                return (
-                <Tooltip key={tool.id}>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => handleToolClick(tool.id)}
-                      disabled={isDisabled}
-                      className={`w-9 h-9 flex items-center justify-center rounded-lg border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-                        activeTool === tool.id
-                          ? "bg-amber-500 border-amber-500 text-white shadow-sm"
-                          : pendingTool === tool.id
-                            ? "bg-amber-100 border-amber-300 text-amber-700"
-                            : "bg-white border-slate-200 text-slate-500 hover:bg-slate-50 hover:border-slate-300"
-                      }`}
-                    >
-                      <tool.icon className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    <p className="font-semibold text-xs">{tool.label}</p>
-                    <p className="text-[10px] opacity-75 mt-0.5">{tool.description}</p>
-                  </TooltipContent>
-                </Tooltip>
-              );
-              })}
-            </div>
-          </TooltipProvider>
-
-          {activeTool === "count" && (
-            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
-              <span className="text-white text-[11px] font-semibold">Count</span>
-              <span className="text-white text-[11px] font-bold"># {countTotal}</span>
-            </div>
-          )}
-          {activeTool === "length" && (
-            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
-              <span className="text-white text-[11px] font-semibold">Length</span>
-              <span className="text-white text-[11px] font-bold">
-                {(lengthTotal + (liveDrawingLength ?? 0)).toFixed(2)} {distanceUnit}
-              </span>
-            </div>
-          )}
-          {activeTool === "area" && (
-            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
-              <span className="text-white text-[11px] font-semibold">Area</span>
-              <span className="text-white text-[11px] font-bold">
-                {areaTotal.toFixed(2)} {distanceUnit === "Meters" ? "m²" : `${distanceUnit}²`}
-              </span>
-            </div>
-          )}
-          {activeTool === "text" && (
-            <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
-              <span className="text-white text-[11px] font-semibold">Text</span>
-            </div>
-          )}
-
-        </div>
-
-        {/* ELEMENTS + DRAWINGS drawer */}
-        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          {/* ELEMENT section label */}
-          <div className="px-3 py-2 border-b border-slate-100 shrink-0">
-            <div className="flex items-center gap-1.5">
-              <Box className="w-3.5 h-3.5 text-slate-400" />
-              <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Element</span>
-            </div>
-          </div>
-
-          {/* Content: elements list (behind) + DRAWINGS drawer (on top) */}
-          <div className="flex-1 min-h-0 relative overflow-hidden">
-
-            {/* ELEMENTS panel — always rendered */}
-            <div className="absolute inset-0 flex flex-col overflow-hidden">
-              <div className="px-2 py-2 border-b border-slate-100 shrink-0">
-                <div className="relative">
-                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
-                  <Input
-                    value={elementSearch}
-                    onChange={(e) => setElementSearch(e.target.value)}
-                    placeholder="Search elements..."
-                    className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white"
-                  />
-                </div>
+      <div className="relative flex h-screen overflow-hidden bg-[#e8edf2]">
+        {/* ── Left sidebar ── */}
+        <aside
+          className={`shrink-0 bg-white border-r border-slate-100 overflow-hidden transition-all duration-300 ease-in-out ${
+            sidebarCollapsed ? "w-0 border-r-0" : "w-[248px]"
+          }`}
+        >
+          {/* Fixed-width inner column so content never reflows while the aside animates —
+          the aside itself just clips it via overflow-hidden. */}
+          <div className="w-[248px] h-full flex flex-col overflow-hidden">
+            {/* Header */}
+            <div className="px-3 py-3 bg-[#fdf8f0] border-b border-amber-100/60 flex items-center gap-2.5">
+              <div className="w-9 h-9 rounded-xl bg-amber-500 flex items-center justify-center shrink-0 shadow-sm">
+                <LayoutGrid className="w-4.5 h-4.5 text-white" />
               </div>
-
-              <div className="flex-1 min-h-0 overflow-y-auto">
-                {Object.keys(elementsByCategory).length === 0 ? (
-                  <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
-                    <Box className="w-8 h-8 text-slate-200" />
-                    <p className="text-[11px] text-slate-400 text-center leading-relaxed">
-                      No elements yet.
-                    </p>
-                    <button
-                      onClick={() => setCreateNewElOpen(true)}
-                      className="flex items-center gap-1.5 text-amber-600 hover:text-amber-700 text-[12px] font-semibold transition-colors"
-                    >
-                      <Plus className="w-3.5 h-3.5" /> Create Elements
-                    </button>
-                  </div>
-                ) : (
-                  <>
-                    {Object.entries(elementsByCategory).map(([category, els]) => (
-                      <div key={category}>
-                        <button
-                          onClick={() => toggleCategory(category)}
-                          className="w-full flex items-center justify-between px-3 py-2 hover:bg-slate-50 transition-colors border-b border-slate-100"
-                        >
-                          <div className="flex items-center gap-2">
-                            <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-                            <span className="text-[10px] font-bold uppercase tracking-widest text-slate-600">
-                              {category}
-                            </span>
-                          </div>
-                          <ChevronDown
-                            className={`w-3 h-3 text-slate-400 transition-transform duration-150 ${expandedCategories.includes(category) ? "" : "-rotate-90"}`}
-                          />
-                        </button>
-
-                        {expandedCategories.includes(category) &&
-                          els.map((el) => (
-                            <button
-                              key={el.id}
-                              onClick={() => handleElementClick(el)}
-                              className="w-full flex items-start gap-2 px-4 py-2 hover:bg-amber-50 transition-colors text-left border-b border-slate-50 group"
-                            >
-                              <FolderOpen className="w-3.5 h-3.5 text-slate-300 group-hover:text-amber-400 shrink-0 mt-0.5 transition-colors" />
-                              <div className="flex-1 min-w-0">
-                                <p className="text-[12px] font-semibold text-slate-700 truncate group-hover:text-amber-700 transition-colors">
-                                  {el.name}
-                                </p>
-                                {el.variants.length > 0 ? (
-                                  <div className="flex items-center gap-1 mt-0.5 flex-wrap">
-                                    <div className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
-                                    <span className="text-[10px] text-slate-500">
-                                      {el.variants.length} variant{el.variants.length !== 1 ? "s" : ""}
-                                    </span>
-                                    <span className="text-[10px] text-slate-400">·</span>
-                                    <span className="text-[10px] text-slate-500">
-                                      {elementTotalDisplay(el.variants)}
-                                    </span>
-                                  </div>
-                                ) : (
-                                  <p className="text-[10px] text-slate-400 mt-0.5">(0 drawn)</p>
-                                )}
-                              </div>
-                              <ChevronRight className="w-3.5 h-3.5 text-slate-300 group-hover:text-amber-400 shrink-0 mt-0.5 transition-colors" />
-                            </button>
-                          ))}
-                      </div>
-                    ))}
-
-                    <div className="px-3 py-2.5">
-                      <button
-                        onClick={() => setCreateNewElOpen(true)}
-                        className="flex items-center gap-1.5 text-amber-600 hover:text-amber-700 text-[12px] font-semibold transition-colors"
-                      >
-                        <Plus className="w-3.5 h-3.5" /> Create Elements
-                      </button>
-                    </div>
-                  </>
-                )}
+              <div className="min-w-0">
+                <p className="text-[12px] font-bold text-slate-800 leading-snug">
+                  QSCalc Pro Workspace
+                </p>
+                <p className="text-[10px] text-slate-500 truncate">
+                  {projectName}
+                </p>
               </div>
             </div>
 
-            {/* DRAWINGS bottom drawer — slides up over elements */}
-            <div
-              className="absolute inset-x-2 bottom-0 flex flex-col overflow-hidden rounded-tl-xl rounded-tr-xl"
-              style={{
-                height: drawingsOpen ? "100%" : "44px",
-                transition: "height 0.3s ease-in-out",
-              }}
-            >
-              {/* DRAWINGS header bar — always visible at top of drawer */}
-              <button
-                onClick={() => setDrawingsOpen((v) => !v)}
-                className="h-11 shrink-0 flex items-center justify-between px-3 bg-amber-500 text-white"
-              >
-                <div className="flex items-center gap-2">
-                  <FolderOpen className="w-4 h-4" />
-                  <span className="text-[12px] font-bold tracking-wide">DRAWINGS</span>
-                </div>
-                <SlidersHorizontal className="w-3.5 h-3.5 opacity-80" />
-              </button>
-
-              {/* DRAWINGS content */}
-              <div className="flex-1 min-h-0 flex flex-col overflow-hidden bg-white">
-                <div className="px-2 py-2 border-b border-slate-100 shrink-0">
-                  <div className="relative">
-                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
-                    <Input
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                      placeholder="Search drawings..."
-                      className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white"
-                    />
-                  </div>
-                </div>
-                <div className="flex-1 overflow-y-auto">
-                  {folders.length === 0 || drawings.filter((d) => d.status === "complete" || d.previewUrl).length === 0 ? (
-                    <div className="flex flex-col items-center justify-center py-8 px-4 text-center gap-2">
-                      <FolderOpen className="w-8 h-8 text-slate-200" />
-                      <p className="text-[11px] text-slate-400 leading-relaxed">
-                        No drawings uploaded yet.
-                        <br />
-                        Use Upload below to add files.
-                      </p>
-                    </div>
-                  ) : (
-                    <div>
-                      {folders.map((folder) => {
-                        const files = getFilesForFolder(folder);
-                        if (files.length === 0 && search) return null;
-                        const isOpen = openFolders.includes(folder.id);
-                        return (
-                          <div key={folder.id}>
-                            {/* Folder header toggle */}
-                            <button
-                              onClick={() =>
-                                setOpenFolders((prev) =>
-                                  isOpen
-                                    ? prev.filter((id) => id !== folder.id)
-                                    : [...prev, folder.id],
-                                )
-                              }
-                              className="w-full flex items-center gap-2 px-3 py-2 hover:bg-slate-50 transition-colors text-left"
-                            >
-                              <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-                              <span className="text-[10px] font-bold text-slate-600 truncate uppercase tracking-widest flex-1">
-                                {folder.name}
-                              </span>
-                              <span className="text-[9px] text-slate-400 shrink-0 font-medium bg-slate-100 px-1.5 py-0.5 rounded-full">
-                                {folder.fileIds.length}
-                              </span>
-                              <ChevronDown
-                                className={`w-3 h-3 text-slate-400 shrink-0 ml-1 transition-transform duration-150 ${
-                                  isOpen ? "" : "-rotate-90"
-                                }`}
-                              />
-                            </button>
-
-                            {/* Files — plain div, no overflow constraint */}
-                            {isOpen && (
-                              <div className="flex flex-col">
-                                {files.length === 0 ? (
-                                  <p className="text-[10px] text-slate-400 px-5 py-1.5 italic">
-                                    No files
-                                  </p>
-                                ) : (
-                                  files.map((file) => (
-                                    <FileRow
-                                      key={file.id}
-                                      file={file}
-                                      isActive={selectedDrawingId === file.id}
-                                      activePage={selectedPage}
-                                      onSelectFile={() => handleSelectFile(file.id)}
-                                      onSelectPage={(pg) => handleSelectPage(file.id, pg)}
-                                    />
-                                  ))
-                                )}
-                              </div>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-                <div className="shrink-0 border-t border-slate-100 flex items-center gap-2 p-2">
-                  <button
-                    onClick={() => setNewFolderOpen(true)}
-                    className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border border-slate-200 text-[11px] font-medium text-slate-600 hover:bg-slate-50 transition-colors"
-                  >
-                    <FolderPlus className="w-3.5 h-3.5" /> New Folder
-                  </button>
-                  <button
-                    onClick={() => fileInputRef.current?.click()}
-                    className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-amber-50 border border-amber-200 text-[11px] font-semibold text-amber-600 hover:bg-amber-100 transition-colors"
-                  >
-                    <Upload className="w-3.5 h-3.5" /> Upload
-                  </button>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    accept={ACCEPTED_EXTENSIONS.join(",")}
-                    className="hidden"
-                    onChange={handleWorkspaceUpload}
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      {/* ── Main area ── */}
-      <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
-        {/* Top bar */}
-        <header className="h-10 shrink-0 bg-white border-b border-slate-200 flex items-center justify-between px-4">
-          <nav className="flex items-center gap-1 text-[11px] text-slate-500 min-w-0">
-            <Home className="w-3 h-3 shrink-0 text-slate-400" />
-            {breadcrumb.map((seg, i) => (
-              <span key={i} className="flex items-center gap-1 min-w-0">
-                <ChevronRight className="w-3 h-3 shrink-0 text-slate-300" />
-                <span className={`truncate max-w-[140px] ${i === breadcrumb.length - 1 ? "text-slate-700 font-semibold" : ""}`}>
-                  {seg.label}
-                </span>
-              </span>
-            ))}
-          </nav>
-          <div className="flex items-center gap-2.5 shrink-0">
-            {autoSaveStatus === "saving" ? (
-              <span className="flex items-center gap-1 text-[10px] text-amber-500">
-                <div className="w-2.5 h-2.5 border border-amber-400 border-t-transparent rounded-full animate-spin" />
-                Saving...
-              </span>
-            ) : (
-              <span className="flex items-center gap-1 text-[10px] text-slate-400">
-                <Save className="w-3 h-3" />
-                {autoSaveStatus === "saved" ? "Auto-saved just now" : "Auto-saved just now"}
-              </span>
-            )}
-            {scaleLocked && (
-              <div className="flex items-center gap-1.5 px-2.5 py-1 bg-green-100 rounded-lg border border-green-200">
-                <Lock className="w-3 h-3 text-green-600" />
-                <span className="text-[10px] font-semibold text-green-700">Scale Locked</span>
-              </div>
-            )}
-            {scaleFlowActive && (
-              <button
-                onClick={handleViewBoq}
-                disabled={finalizing}
-                className="flex items-center gap-1.5 px-3 py-1 bg-amber-500 hover:bg-amber-600 rounded-lg text-white text-[11px] font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {finalizing ? (
-                  <div className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
-                ) : (
-                  <FileUp className="w-3 h-3" />
-                )}
-                View BOQ
-              </button>
-            )}
-          </div>
-        </header>
-
-        {/* Canvas row */}
-        <div className="flex-1 min-h-0 flex overflow-hidden">
-          <div className="flex-1 min-w-0 relative overflow-hidden bg-[#e8edf2]">
-            <DrawingCanvas
-              drawing={selectedDrawing}
-              page={selectedPage}
-              scale={scale}
-              onPageCountResolved={handlePageCountResolved}
-              measurementOverlay={
-                <MeasurementCanvas
-                  pdfScale={scale}
-                  activeTool={activeTool}
-                  isCalibrating={scaleFlowActive && !scaleLocked}
-                  scaleFactor={globalScaleFactor}
-                  distanceUnit={distanceUnit}
-                  activeColor={activeColor}
-                  measurements={measurementHook.state.measurements}
-                  nextCountIndex={nextCountIndex}
-                  pageKey={`${selectedDrawingId ?? "none"}-${selectedPage}`}
-                  onCalibrationUpdate={handleCalibrationUpdate}
-                  onMeasurementAdd={handleMeasurementAdd}
-                  onLiveLength={setLiveDrawingLength}
-                  onUndo={measurementHook.undo}
-                  onRedo={measurementHook.redo}
-                />
-              }
-            />
-
-            {/* Zoom controls */}
-            <div className="absolute bottom-4 left-4 flex flex-col gap-1 bg-white rounded-lg shadow-md border border-slate-200 p-1">
-              <button onClick={zoomIn} disabled={scale >= 3} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40" title="Zoom in">
-                <ZoomIn className="w-3.5 h-3.5" />
-              </button>
-              <button onClick={zoomOut} disabled={scale <= 0.25} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40" title="Zoom out">
-                <ZoomOut className="w-3.5 h-3.5" />
-              </button>
-              <button onClick={resetZoom} className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500" title="Reset zoom">
-                <Maximize2 className="w-3.5 h-3.5" />
-              </button>
-            </div>
-
-            {/* Page indicator */}
-            {selectedDrawing && (
-              <div className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-white rounded-lg shadow-md border border-slate-200 px-3 py-1.5 text-[11px] text-slate-600 font-medium">
-                <FileUp className="w-3.5 h-3.5 text-amber-500" />
-                Page {selectedPage}
-                {selectedDrawing.name && (
-                  <span className="text-slate-400">— {selectedDrawing.name.replace(/\.[^.]+$/, "")}</span>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Element detail panel */}
-          {showElementPanel && (
-            <ElementDetailPanel
-              measure={scaleWhat}
-              showRebarTab={showRebarTab}
-              activeMeasureTool={
-                activeTool === "length" || activeTool === "area" || activeTool === "count"
-                  ? activeTool
-                  : null
-              }
-              liveCount={sessionTotals.count}
-              liveLength={sessionTotals.length + (liveDrawingLength ?? 0)}
-              liveArea={sessionTotals.area}
-              distanceUnit={distanceUnit}
-              hasMeasurements={
-                sessionTotals.count > 0 || sessionTotals.length > 0 || sessionTotals.area > 0
-              }
-              activeColor={activeColor}
-              onColorChange={setActiveColor}
-              onClose={() => setShowElementPanel(false)}
-              onAssignElement={() => {
-                if (concreteMeasurements.length === 0) {
-                  toast.warning("Take a measurement on the drawing first — draw some marks before assigning an element.");
-                  return;
+            {/* Dashboard */}
+            <div className="px-3 py-1 border-b border-slate-100 flex items-center gap-1.5">
+              <a
+                href={
+                  basePath.startsWith("/enterprise")
+                    ? "/enterprise/dashboard"
+                    : "/dashboard"
                 }
-                setAssignModalOpen(true);
-              }}
-              onApplyAndContinue={handleSessionReset}
-              onSaveMeasurement={handleSaveMeasurement}
-              onFormChange={handleAutoSave}
-              onResetMeasurements={handleSessionReset}
-            />
-          )}
-        </div>
+                className="flex-1 min-w-0 flex items-center gap-3 px-2 py-2.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-50 transition-colors"
+              >
+                <Home className="w-4 h-4 shrink-0" />
+                <span className="text-[11px] font-bold uppercase tracking-widest">
+                  Dashboard
+                </span>
+              </a>
+              <button
+                onClick={handleSidebarToggle}
+                title="Collapse sidebar"
+                className="w-8 h-8 flex items-center justify-center rounded-lg bg-amber-500 hover:bg-amber-600 text-white shrink-0 transition-colors"
+              >
+                <Minimize2 className="w-4 h-4" />
+              </button>
+            </div>
 
-        {/* Calibration / Ready bar */}
-        {scaleFlowActive && (
-          <div className="shrink-0 bg-white border-t border-slate-200">
-            {!scaleLocked ? (
-              <div className="px-6 pt-3 pb-5" style={{ backgroundColor: "#FEF2F280" }}>
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-2">
-                    <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${scaleInfo ? "bg-amber-500" : "bg-red-500"}`} />
-                    <span className={`text-[11px] font-bold tracking-wide ${scaleInfo ? "text-amber-600" : "text-red-600"}`}>
-                      {scaleInfo ? "SCALE APPLIED — Lock when ready" : "CALIBRATION REQUIRED"}
+            {/* Tools */}
+            <div className="px-3 pt-3 pb-2.5 border-b border-slate-100">
+              <div className="flex items-center gap-1.5 mb-2.5">
+                <Wrench className="w-3.5 h-3.5 text-slate-400" />
+                <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                  Tools
+                </span>
+              </div>
+              <TooltipProvider delayDuration={400}>
+                <div className="flex gap-1.5">
+                  {TOOLS.map((tool) => {
+                    const isDisabled =
+                      (tool.id === "undo" && !measurementHook.canUndo) ||
+                      (tool.id === "redo" && !measurementHook.canRedo);
+                    return (
+                      <Tooltip key={tool.id}>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={() => handleToolClick(tool.id)}
+                            disabled={isDisabled}
+                            className={`w-9 h-9 flex items-center justify-center rounded-lg border transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                              activeTool === tool.id
+                                ? "bg-amber-500 border-amber-500 text-white shadow-sm"
+                                : pendingTool === tool.id
+                                  ? "bg-amber-100 border-amber-300 text-amber-700"
+                                  : "bg-white border-slate-200 text-slate-500 hover:bg-slate-50 hover:border-slate-300"
+                            }`}
+                          >
+                            <tool.icon className="w-4 h-4" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={6}>
+                          <p className="font-semibold text-xs">{tool.label}</p>
+                          <p className="text-[10px] opacity-75 mt-0.5">
+                            {tool.description}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              </TooltipProvider>
+
+              {activeTool === "count" && (
+                <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+                  <span className="text-white text-[11px] font-semibold">
+                    Count
+                  </span>
+                  <span className="text-white text-[11px] font-bold">
+                    # {countTotal}
+                  </span>
+                </div>
+              )}
+              {activeTool === "length" && (
+                <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+                  <span className="text-white text-[11px] font-semibold">
+                    Length
+                  </span>
+                  <span className="text-white text-[11px] font-bold">
+                    {(lengthTotal + (liveDrawingLength ?? 0)).toFixed(2)}{" "}
+                    {distanceUnit}
+                  </span>
+                </div>
+              )}
+              {activeTool === "area" && (
+                <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+                  <span className="text-white text-[11px] font-semibold">
+                    Area
+                  </span>
+                  <span className="text-white text-[11px] font-bold">
+                    {areaTotal.toFixed(2)}{" "}
+                    {distanceUnit === "Meters" ? "m²" : `${distanceUnit}²`}
+                  </span>
+                </div>
+              )}
+              {activeTool === "text" && (
+                <div className="mt-2 flex items-center justify-between px-3 py-1.5 bg-slate-700 rounded-lg">
+                  <span className="text-white text-[11px] font-semibold">
+                    Text
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* ELEMENTS + DRAWINGS drawer */}
+            <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+              {/* ELEMENT section label */}
+              <div className="px-3 py-2 border-b border-slate-100 shrink-0">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <Box className="w-3.5 h-3.5 text-slate-400" />
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                      Elements
                     </span>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-[11px] text-slate-500">Lock Scale:</span>
-                    <button
-                      disabled={!scaleInfo}
-                      onClick={() => { setScaleLocked(true); saveSession(projectId, { scaleLocked: true }); }}
-                      className={`relative w-9 h-5 rounded-full transition-colors ${scaleInfo ? "bg-slate-200 hover:bg-slate-300 cursor-pointer" : "bg-slate-100 cursor-not-allowed"}`}
-                    >
-                      <span className="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200" />
-                    </button>
-                    <span className="text-[11px] font-semibold text-slate-500">OFF</span>
-                  </div>
+                  <button
+                    onClick={handleAddNewElement}
+                    className="text-[10px] font-bold uppercase tracking-widest text-amber-600 hover:text-amber-700 transition-colors"
+                  >
+                    + New Element
+                  </button>
                 </div>
+              </div>
 
-                <div className="flex items-start gap-6">
-                  <div className="w-1/3 space-y-3 shrink-0">
-                    {/* Step 1 — dynamic based on points placed */}
-                    <div className="flex items-start gap-2">
-                      <div className={`w-5 h-5 rounded-full text-white flex items-center justify-center text-[10px] font-bold shrink-0 mt-px ${calibPtCount === 2 ? "bg-green-500" : "bg-amber-500"}`}>
-                        1
-                      </div>
-                      <span className={`text-[11px] leading-snug ${calibPtCount === 2 ? "text-green-600 font-medium" : "text-slate-600"}`}>
-                        {calibPtCount === 0 && "Click the first point on a known distance on the plan."}
-                        {calibPtCount === 1 && "✓ Point 1 set — click the second point."}
-                        {calibPtCount === 2 && `✓ Both points set — ${calibBasePxDist?.toFixed(0)} px measured.`}
-                      </span>
-                    </div>
-                    {/* Step 2 */}
-                    <div className="flex items-start gap-2">
-                      <div className="w-5 h-5 rounded-full bg-amber-500 text-white flex items-center justify-center text-[10px] font-bold shrink-0 mt-px">
-                        2
-                      </div>
-                      <span className="text-[11px] text-slate-600 leading-snug">Enter the real length below.</span>
+              {/* Content: elements list (behind) + DRAWINGS drawer (on top) */}
+              <div className="flex-1 min-h-0 relative overflow-hidden">
+                {/* ELEMENTS panel — always rendered */}
+                <div className="absolute inset-0 flex flex-col overflow-hidden">
+                  <div className="px-2 py-2 border-b border-slate-100 shrink-0">
+                    <div className="relative">
+                      <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
+                      <Input
+                        value={elementSearch}
+                        onChange={(e) => setElementSearch(e.target.value)}
+                        placeholder="Search elements..."
+                        className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white"
+                      />
                     </div>
                   </div>
 
-                  <div className="w-2/3 space-y-2">
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">Known Distance on Plan</span>
-                    <div className="flex items-center gap-2">
-                      <Input value={knownDistance} onChange={(e) => setKnownDistance(e.target.value)} className="h-9 flex-1 text-sm" placeholder="0" />
-                      <Select value={distanceUnit} onValueChange={setDistanceUnit}>
-                        <SelectTrigger className="h-9 w-28 text-[11px] shrink-0"><SelectValue /></SelectTrigger>
-                        <SelectContent>
-                          {["Meters", "mm", "cm", "ft"].map((u) => <SelectItem key={u} value={u}>{u}</SelectItem>)}
-                        </SelectContent>
-                      </Select>
-                      <Button onClick={handleApplyScale} className="h-9 bg-amber-500 hover:bg-amber-600 text-white text-[12px] font-semibold px-5 shrink-0">
-                        Apply Scale
-                      </Button>
-                    </div>
-
-                    {showScaleNotification && scaleInfo && (
-                      <div className="flex items-center gap-3 px-4 py-2 bg-green-50 border border-green-200 rounded-lg">
-                        <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
-                        <span className="text-[12px] font-bold text-green-700">{scaleInfo}</span>
-                        <button onClick={handleResetScale} className="ml-auto text-[11px] font-semibold text-red-500 hover:text-red-700 transition-colors">
-                          Reset
+                  <div className="flex-1 min-h-0 overflow-y-auto">
+                    {Object.keys(elementsByCategory).length === 0 ? (
+                      <div className="flex flex-col items-center justify-center h-full px-4 gap-3">
+                        <Box className="w-8 h-8 text-slate-200" />
+                        <p className="text-[11px] text-slate-400 text-center leading-relaxed">
+                          No elements yet.
+                        </p>
+                        <button
+                          onClick={() => setCreateNewElOpen(true)}
+                          className="flex items-center gap-1.5 text-amber-600 hover:text-amber-700 text-[12px] font-semibold transition-colors"
+                        >
+                          <Plus className="w-3.5 h-3.5" /> Create Elements
                         </button>
                       </div>
+                    ) : (
+                      <>
+                        {Object.entries(elementsByCategory).map(
+                          ([category, els]) => (
+                            <div key={category}>
+                              <button
+                                onClick={() => toggleCategory(category)}
+                                className="w-full flex items-center justify-between px-3 py-2 hover:bg-slate-50 transition-colors border-b border-slate-100"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                                  <span className="text-[10px] font-bold uppercase tracking-widest text-slate-600">
+                                    {category}
+                                  </span>
+                                </div>
+                                <ChevronDown
+                                  className={`w-3 h-3 text-slate-400 transition-transform duration-150 ${expandedCategories.includes(category) ? "" : "-rotate-90"}`}
+                                />
+                              </button>
+
+                              {expandedCategories.includes(category) &&
+                                els.map((el) => (
+                                  <button
+                                    key={el.id}
+                                    onClick={() => handleElementClick(el)}
+                                    className="w-full flex items-start gap-2 px-4 py-2 hover:bg-amber-50 transition-colors text-left border-b border-slate-50 group"
+                                  >
+                                    <FolderOpen className="w-3.5 h-3.5 text-slate-300 group-hover:text-amber-400 shrink-0 mt-0.5 transition-colors" />
+                                    <div className="flex-1 min-w-0">
+                                      <p className="text-[12px] font-semibold text-slate-700 truncate group-hover:text-amber-700 transition-colors">
+                                        {el.name}
+                                      </p>
+                                      {el.variants.length > 0 ? (
+                                        <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+                                          <div className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
+                                          <span className="text-[10px] text-slate-500">
+                                            {el.variants.length} variant
+                                            {el.variants.length !== 1
+                                              ? "s"
+                                              : ""}
+                                          </span>
+                                          <span className="text-[10px] text-slate-400">
+                                            ·
+                                          </span>
+                                          <span className="text-[10px] text-slate-500">
+                                            {elementTotalDisplay(el.variants)}
+                                          </span>
+                                        </div>
+                                      ) : (
+                                        <p className="text-[10px] text-slate-400 mt-0.5">
+                                          (0 drawn)
+                                        </p>
+                                      )}
+                                    </div>
+                                    <ChevronRight className="w-3.5 h-3.5 text-slate-300 group-hover:text-amber-400 shrink-0 mt-0.5 transition-colors" />
+                                  </button>
+                                ))}
+                            </div>
+                          ),
+                        )}
+
+                        <div className="px-3 py-2.5">
+                          <button
+                            onClick={() => setCreateNewElOpen(true)}
+                            className="flex items-center gap-1.5 text-amber-600 hover:text-amber-700 text-[12px] font-semibold transition-colors"
+                          >
+                            <Plus className="w-3.5 h-3.5" /> Create Elements
+                          </button>
+                        </div>
+                      </>
                     )}
                   </div>
                 </div>
+
+                {/* DRAWINGS bottom drawer — slides up over elements */}
+                <div
+                  className="absolute inset-x-2 bottom-0 flex flex-col overflow-hidden rounded-tl-xl rounded-tr-xl"
+                  style={{
+                    height: drawingsOpen ? "100%" : "44px",
+                    transition: "height 0.3s ease-in-out",
+                  }}
+                >
+                  {/* DRAWINGS header bar — always visible at top of drawer */}
+                  <button
+                    onClick={() => setDrawingsOpen((v) => !v)}
+                    className="h-11 shrink-0 flex items-center justify-between px-3 bg-amber-500 text-white"
+                  >
+                    <div className="flex items-center gap-2">
+                      <FolderOpen className="w-4 h-4" />
+                      <span className="text-[12px] font-bold tracking-wide">
+                        DRAWINGS
+                      </span>
+                    </div>
+                    <SlidersHorizontal className="w-3.5 h-3.5 opacity-80" />
+                  </button>
+
+                  {/* DRAWINGS content */}
+                  <div className="flex-1 min-h-0 flex flex-col overflow-hidden bg-white">
+                    <div className="px-2 py-2 border-b border-slate-100 shrink-0">
+                      <div className="relative">
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-slate-400" />
+                        <Input
+                          value={search}
+                          onChange={(e) => setSearch(e.target.value)}
+                          placeholder="Search drawings..."
+                          className="h-7 pl-7 text-[11px] border-slate-200 bg-slate-50/50 focus:bg-white"
+                        />
+                      </div>
+                    </div>
+                    <div className="flex-1 overflow-y-auto">
+                      {folders.length === 0 ||
+                      drawings.filter(
+                        (d) => d.status === "complete" || d.previewUrl,
+                      ).length === 0 ? (
+                        <div className="flex flex-col items-center justify-center py-8 px-4 text-center gap-2">
+                          <FolderOpen className="w-8 h-8 text-slate-200" />
+                          <p className="text-[11px] text-slate-400 leading-relaxed">
+                            No drawings uploaded yet.
+                            <br />
+                            Use Upload below to add files.
+                          </p>
+                        </div>
+                      ) : (
+                        <div>
+                          {folders.map((folder) => {
+                            const files = getFilesForFolder(folder);
+                            if (files.length === 0 && search) return null;
+                            const isOpen = openFolders.includes(folder.id);
+                            return (
+                              <div key={folder.id}>
+                                {/* Folder header toggle */}
+                                <button
+                                  onClick={() =>
+                                    setOpenFolders((prev) =>
+                                      isOpen
+                                        ? prev.filter((id) => id !== folder.id)
+                                        : [...prev, folder.id],
+                                    )
+                                  }
+                                  className="w-full flex items-center gap-2 px-3 py-2 hover:bg-slate-50 transition-colors text-left"
+                                >
+                                  <FolderOpen className="w-3.5 h-3.5 text-amber-500 shrink-0" />
+                                  <span className="text-[10px] font-bold text-slate-600 truncate uppercase tracking-widest flex-1">
+                                    {folder.name}
+                                  </span>
+                                  <span className="text-[9px] text-slate-400 shrink-0 font-medium bg-slate-100 px-1.5 py-0.5 rounded-full">
+                                    {folder.fileIds.length}
+                                  </span>
+                                  <ChevronDown
+                                    className={`w-3 h-3 text-slate-400 shrink-0 ml-1 transition-transform duration-150 ${
+                                      isOpen ? "" : "-rotate-90"
+                                    }`}
+                                  />
+                                </button>
+
+                                {/* Files — plain div, no overflow constraint */}
+                                {isOpen && (
+                                  <div className="flex flex-col">
+                                    {files.length === 0 ? (
+                                      <p className="text-[10px] text-slate-400 px-5 py-1.5 italic">
+                                        No files
+                                      </p>
+                                    ) : (
+                                      files.map((file) => (
+                                        <FileRow
+                                          key={file.id}
+                                          file={file}
+                                          isActive={
+                                            selectedDrawingId === file.id
+                                          }
+                                          activePage={selectedPage}
+                                          onSelectFile={() =>
+                                            handleSelectFile(file.id)
+                                          }
+                                          onSelectPage={(pg) =>
+                                            handleSelectPage(file.id, pg)
+                                          }
+                                        />
+                                      ))
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 border-t border-slate-100 flex items-center gap-2 p-2">
+                      <button
+                        onClick={() => setNewFolderOpen(true)}
+                        className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg border border-slate-200 text-[11px] font-medium text-slate-600 hover:bg-slate-50 transition-colors"
+                      >
+                        <FolderPlus className="w-3.5 h-3.5" /> New Folder
+                      </button>
+                      <button
+                        onClick={() => fileInputRef.current?.click()}
+                        className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-amber-50 border border-amber-200 text-[11px] font-semibold text-amber-600 hover:bg-amber-100 transition-colors"
+                      >
+                        <Upload className="w-3.5 h-3.5" /> Upload
+                      </button>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept={ACCEPTED_EXTENSIONS.join(",")}
+                        className="hidden"
+                        onChange={handleWorkspaceUpload}
+                      />
+                    </div>
+                  </div>
+                </div>
               </div>
-            ) : (
-              <div>
-                <div className="flex items-center justify-between px-6 py-2.5">
-                  <div className="flex items-center gap-2">
-                    <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
-                    <span className="text-[12px] font-semibold text-green-600">
-                      Ready to measure. Click line tool and trace any wall.
+            </div>
+          </div>
+        </aside>
+
+        {/* Floating compact header — shown only while the sidebar is collapsed */}
+        {sidebarCollapsed && (
+          <div className="absolute top-3 left-3 z-30 flex items-center gap-2.5 bg-[#fdf8f0] border border-amber-100/60 rounded-xl shadow-md px-3 py-2 animate-in fade-in zoom-in-95 duration-200">
+            <div className="w-9 h-9 rounded-xl bg-amber-500 flex items-center justify-center shrink-0 shadow-sm">
+              <LayoutGrid className="w-4.5 h-4.5 text-white" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[12px] font-bold text-slate-800 leading-snug">
+                QSCalc Pro Workspace
+              </p>
+              <p className="text-[10px] text-slate-500 truncate">
+                {projectName}
+              </p>
+            </div>
+            <button
+              onClick={handleSidebarToggle}
+              title="Expand sidebar"
+              className="w-8 h-8 flex items-center justify-center rounded-lg bg-amber-500 hover:bg-amber-600 text-white shrink-0 transition-colors ml-1"
+            >
+              <Maximize2 className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
+        {/* ── Main area ── */}
+        <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+          {/* Top bar */}
+          <header className="h-10 shrink-0 bg-white border-b border-slate-200 flex items-center justify-between px-4">
+            <nav className="flex items-center gap-1 text-[11px] text-slate-500 min-w-0">
+              <Home className="w-3 h-3 shrink-0 text-slate-400" />
+              {breadcrumb.map((seg, i) => (
+                <span key={i} className="flex items-center gap-1 min-w-0">
+                  <ChevronRight className="w-3 h-3 shrink-0 text-slate-300" />
+                  <span
+                    className={`truncate max-w-[140px] ${i === breadcrumb.length - 1 ? "text-slate-700 font-semibold" : ""}`}
+                  >
+                    {seg.label}
+                  </span>
+                </span>
+              ))}
+            </nav>
+            <div className="flex items-center gap-2.5 shrink-0">
+              {autoSaveStatus === "saving" ? (
+                <span className="flex items-center gap-1 text-[10px] text-amber-500">
+                  <div className="w-2.5 h-2.5 border border-amber-400 border-t-transparent rounded-full animate-spin" />
+                  Saving...
+                </span>
+              ) : (
+                <span className="flex items-center gap-1 text-[10px] text-slate-400">
+                  <Save className="w-3 h-3" />
+                  {autoSaveStatus === "saved"
+                    ? "Auto-saved just now"
+                    : "Auto-saved just now"}
+                </span>
+              )}
+              {scaleLocked && (
+                <div className="flex items-center gap-1.5 px-2.5 py-1 bg-green-100 rounded-lg border border-green-200">
+                  <Lock className="w-3 h-3 text-green-600" />
+                  <span className="text-[10px] font-semibold text-green-700">
+                    Scale Locked
+                  </span>
+                </div>
+              )}
+              {scaleFlowActive && (
+                <button
+                  onClick={handleViewBoq}
+                  disabled={finalizing}
+                  className="flex items-center gap-1.5 px-3 py-1 bg-amber-500 hover:bg-amber-600 rounded-lg text-white text-[11px] font-semibold transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {finalizing ? (
+                    <div className="w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+                  ) : (
+                    <FileUp className="w-3 h-3" />
+                  )}
+                  View BOQ
+                </button>
+              )}
+            </div>
+          </header>
+
+          {/* Canvas row */}
+          <div className="flex-1 min-h-0 flex overflow-hidden">
+            <div
+              ref={canvasAreaRef}
+              onWheel={handleCanvasWheel}
+              className="flex-1 min-w-0 relative overflow-hidden bg-[#e8edf2]"
+            >
+              <DrawingCanvas
+                drawing={selectedDrawing}
+                page={selectedPage}
+                scale={scale}
+                onPageCountResolved={handlePageCountResolved}
+                measurementOverlay={
+                  <MeasurementCanvas
+                    pdfScale={scale}
+                    activeTool={activeTool}
+                    isCalibrating={scaleFlowActive && !scaleLocked}
+                    scaleFactor={globalScaleFactor}
+                    distanceUnit={distanceUnit}
+                    activeColor={activeColor}
+                    measurements={measurementHook.state.measurements}
+                    nextCountIndex={nextCountIndex}
+                    pageKey={`${selectedDrawingId ?? "none"}-${selectedPage}`}
+                    onCalibrationUpdate={handleCalibrationUpdate}
+                    onMeasurementAdd={handleMeasurementAdd}
+                    onLiveLength={setLiveDrawingLength}
+                    onUndo={measurementHook.undo}
+                    onRedo={measurementHook.redo}
+                  />
+                }
+              />
+
+              {/* Zoom controls */}
+              <div className="absolute top-4 left-4 flex flex-col gap-1 bg-white rounded-lg shadow-md border border-slate-200 p-1">
+                <button
+                  onClick={zoomIn}
+                  disabled={scale >= 3}
+                  className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40"
+                  title="Zoom in"
+                >
+                  <ZoomIn className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={zoomOut}
+                  disabled={scale <= 0.25}
+                  className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500 disabled:opacity-40"
+                  title="Zoom out"
+                >
+                  <ZoomOut className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={resetZoom}
+                  className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500"
+                  title="Reset zoom"
+                >
+                  <Maximize2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+
+              {/* Page indicator */}
+              {selectedDrawing && (
+                <div className="absolute bottom-4 right-4 flex items-center gap-1.5 bg-white rounded-lg shadow-md border border-slate-200 px-3 py-1.5 text-[11px] text-slate-600 font-medium">
+                  <FileUp className="w-3.5 h-3.5 text-amber-500" />
+                  Page {selectedPage}
+                  {selectedDrawing.name && (
+                    <span className="text-slate-400">
+                      — {selectedDrawing.name.replace(/\.[^.]+$/, "")}
                     </span>
+                  )}
+                </div>
+              )}
+
+              {/* Floating Element Detail Panel — draggable, collapsible, position persists */}
+              {showElementPanel && (
+                <div
+                  ref={elementPanelRef}
+                  className={`absolute z-20 ${elementPanelPos ? "" : "right-6 top-4"}`}
+                  style={
+                    elementPanelPos
+                      ? { left: elementPanelPos.x, top: elementPanelPos.y }
+                      : undefined
+                  }
+                >
+                  {elementPanelCollapsed ? (
+                    <button
+                      onPointerDown={handlePanelDragStart}
+                      onPointerMove={handlePanelDragMove}
+                      onPointerUp={() => {
+                        handlePanelDragEnd();
+                        handlePanelToggleCollapsed();
+                      }}
+                      style={{ touchAction: "none" }}
+                      title="Expand element panel"
+                      className="relative w-14 h-14 rounded-full bg-amber-500 hover:bg-amber-600 text-white shadow-lg flex items-center justify-center cursor-grab active:cursor-grabbing animate-in fade-in zoom-in-90 duration-200"
+                    >
+                      <Box className="w-5 h-5" />
+                      {(sessionTotals.count > 0 ||
+                        sessionTotals.length > 0 ||
+                        sessionTotals.area > 0) && (
+                        <span className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-green-500 border-2 border-white" />
+                      )}
+                    </button>
+                  ) : (
+                    <div className="w-[290px] rounded-xl shadow-xl border border-slate-200 overflow-hidden animate-in fade-in zoom-in-95 duration-200 origin-top-right">
+                      <ElementDetailPanel
+                        measure={scaleWhat}
+                        measureChoice={columnMeasureChoice}
+                        showRebarTab={showRebarTab}
+                        activeMeasureTool={concreteToolForCategory}
+                        liveCount={sessionTotals.count}
+                        liveLength={effectiveConcreteLength}
+                        liveArea={sessionTotals.area}
+                        liveRebarLength={rebarDrawnLength}
+                        distanceUnit={distanceUnit}
+                        hasMeasurements={
+                          sessionTotals.count > 0 ||
+                          sessionTotals.length > 0 ||
+                          sessionTotals.area > 0
+                        }
+                        activeColor={activeColor}
+                        onColorChange={setActiveColor}
+                        onClose={handlePanelToggleCollapsed}
+                        onAssignElement={() => {
+                          if (concreteMeasurements.length === 0) {
+                            toast.warning(
+                              "Take a measurement on the drawing first — draw some marks before assigning an element.",
+                            );
+                            return;
+                          }
+                          setAssignModalOpen(true);
+                        }}
+                        onApplyAndContinue={handleSessionReset}
+                        onSaveMeasurement={handleSaveMeasurement}
+                        onFormChange={handleAutoSave}
+                        onResetMeasurements={handleSessionReset}
+                        onTabChange={handleElementPanelTabChange}
+                        dragHandleProps={{
+                          onPointerDown: handlePanelDragStart,
+                          onPointerMove: handlePanelDragMove,
+                          onPointerUp: handlePanelDragEnd,
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Calibration / Ready bar */}
+          {scaleFlowActive && (
+            <div className="shrink-0 bg-white border-t border-slate-200">
+              {!scaleInfo ? (
+                <div
+                  className="px-6 pt-3 pb-5"
+                  style={{ backgroundColor: "#FEF2F280" }}
+                >
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center gap-2">
+                      <div className="w-2.5 h-2.5 rounded-full shrink-0 bg-red-500" />
+                      <span className="text-[11px] font-bold tracking-wide text-red-600">
+                        CALIBRATION REQUIRED
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-start gap-6">
+                    <div className="w-1/3 space-y-3 shrink-0">
+                      {/* Step 1 — dynamic based on points placed */}
+                      <div className="flex items-start gap-2">
+                        <div
+                          className={`w-5 h-5 rounded-full text-white flex items-center justify-center text-[10px] font-bold shrink-0 mt-px ${calibPtCount === 2 ? "bg-green-500" : "bg-amber-500"}`}
+                        >
+                          1
+                        </div>
+                        <span
+                          className={`text-[11px] leading-snug ${calibPtCount === 2 ? "text-green-600 font-medium" : "text-slate-600"}`}
+                        >
+                          {calibPtCount === 0 &&
+                            "Click the first point on a known distance on the plan."}
+                          {calibPtCount === 1 &&
+                            "✓ Point 1 set — click the second point."}
+                          {calibPtCount === 2 &&
+                            `✓ Both points set — ${calibBasePxDist?.toFixed(0)} px measured.`}
+                        </span>
+                      </div>
+                      {/* Step 2 */}
+                      <div className="flex items-start gap-2">
+                        <div className="w-5 h-5 rounded-full bg-amber-500 text-white flex items-center justify-center text-[10px] font-bold shrink-0 mt-px">
+                          2
+                        </div>
+                        <span className="text-[11px] text-slate-600 leading-snug">
+                          Enter the real length below.
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="w-2/3 space-y-2">
+                      <span className="text-[10px] font-bold uppercase tracking-widest text-slate-500">
+                        Known Distance on Plan
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          value={knownDistance}
+                          onChange={(e) => setKnownDistance(e.target.value)}
+                          className="h-9 flex-1 text-sm"
+                          placeholder="0"
+                          disabled={applyingScale}
+                        />
+                        <Select
+                          value={distanceUnit}
+                          onValueChange={setDistanceUnit}
+                        >
+                          <SelectTrigger className="h-9 w-28 text-[11px] shrink-0">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {["Meters", "mm", "cm", "ft"].map((u) => (
+                              <SelectItem key={u} value={u}>
+                                {u}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          onClick={handleApplyScale}
+                          disabled={applyingScale}
+                          className="h-9 bg-amber-500 hover:bg-amber-600 text-white text-[12px] font-semibold px-5 shrink-0 disabled:opacity-60"
+                        >
+                          {applyingScale ? "Saving…" : "Apply Scale"}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : !scaleLocked ? (
+                <div
+                  className="px-6 py-3 flex items-center justify-between"
+                  style={{ backgroundColor: "#FEF2F280" }}
+                >
+                  <div className="flex items-center gap-3">
+                    <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                    <span className="text-[12px] font-bold text-green-700">
+                      {scaleInfo}
+                    </span>
+                    {showScaleNotification && (
+                      <span className="text-[10px] font-semibold text-amber-600 uppercase tracking-wide">
+                        Saved
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="flex items-center gap-2">
-                      <span className="text-[11px] text-slate-500">Lock Scale:</span>
+                      <span className="text-[11px] text-slate-500">
+                        Lock Scale:
+                      </span>
                       <button
-                        onClick={() => { setScaleLocked(false); saveSession(projectId, { scaleLocked: false }); }}
-                        className="relative w-9 h-5 rounded-full bg-green-500 transition-colors"
+                        onClick={() => {
+                          setScaleLocked(true);
+                          saveSession(projectId, { scaleLocked: true });
+                        }}
+                        className="relative w-9 h-5 rounded-full bg-slate-200 hover:bg-slate-300 cursor-pointer transition-colors"
                       >
-                        <span className="absolute top-0.5 right-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200" />
+                        <span className="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200" />
                       </button>
-                      <span className="text-[11px] font-bold text-green-600">ON</span>
+                      <span className="text-[11px] font-semibold text-slate-500">
+                        OFF
+                      </span>
                     </div>
-                    <button onClick={handleResetScale} className="text-[11px] text-slate-500 hover:text-slate-700 font-medium transition-colors">
-                      Edit Calibration
+                    <button
+                      onClick={handleResetScale}
+                      className="text-[11px] font-semibold text-red-500 hover:text-red-700 transition-colors"
+                    >
+                      Reset Scale
                     </button>
                   </div>
                 </div>
+              ) : (
+                <div>
+                  <div className="flex items-center justify-between px-6 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0" />
+                      <span className="text-[12px] font-semibold text-green-600">
+                        Ready to measure. Click line tool and trace any wall.
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      <div className="flex items-center gap-2">
+                        <span className="text-[11px] text-slate-500">
+                          Lock Scale:
+                        </span>
+                        <button
+                          onClick={() => {
+                            setScaleLocked(false);
+                            saveSession(projectId, { scaleLocked: false });
+                          }}
+                          className="relative w-9 h-5 rounded-full bg-green-500 transition-colors"
+                        >
+                          <span className="absolute top-0.5 right-0.5 w-4 h-4 rounded-full bg-white shadow transition-all duration-200" />
+                        </button>
+                        <span className="text-[11px] font-bold text-green-600">
+                          ON
+                        </span>
+                      </div>
+                      <button
+                        onClick={handleResetScale}
+                        className="text-[11px] text-slate-500 hover:text-slate-700 font-medium transition-colors"
+                      >
+                        Edit Calibration
+                      </button>
+                    </div>
+                  </div>
 
-                <div className="flex items-center gap-3 px-6 py-2 bg-amber-50/60 border-t border-amber-100">
-                  <span className="text-[13px] text-amber-500">💡</span>
-                  <span className="text-[10px] font-semibold text-slate-500 shrink-0">Quick tips:</span>
-                  <span className="text-[10px] text-slate-400">Press</span>
-                  {[{ key: "L", label: "for line tool" }, { key: "A", label: "for area" }, { key: "C", label: "for count" }].map(({ key, label }) => (
-                    <span key={key} className="flex items-center gap-1 text-[10px] text-slate-400">
-                      <kbd className="px-1.5 py-0.5 rounded bg-slate-100 border border-slate-200 text-[10px] font-semibold text-slate-600">{key}</kbd>
-                      {label}
+                  <div className="flex items-center gap-3 px-6 py-2 bg-amber-50/60 border-t border-amber-100">
+                    <span className="text-[13px] text-amber-500">💡</span>
+                    <span className="text-[10px] font-semibold text-slate-500 shrink-0">
+                      Quick tips:
                     </span>
-                  ))}
-                  <span className="text-slate-300">•</span>
-                  <span className="text-[10px] text-slate-400">Double-click to finish polygon</span>
-                  <span className="text-slate-300">•</span>
-                  <span className="text-[10px] text-slate-400">Right-click to cancel</span>
+                    <span className="text-[10px] text-slate-400">Press</span>
+                    {[
+                      { key: "L", label: "for line tool" },
+                      { key: "A", label: "for area" },
+                      { key: "C", label: "for count" },
+                    ].map(({ key, label }) => (
+                      <span
+                        key={key}
+                        className="flex items-center gap-1 text-[10px] text-slate-400"
+                      >
+                        <kbd className="px-1.5 py-0.5 rounded bg-slate-100 border border-slate-200 text-[10px] font-semibold text-slate-600">
+                          {key}
+                        </kbd>
+                        {label}
+                      </span>
+                    ))}
+                    <span className="text-slate-300">•</span>
+                    <span className="text-[10px] text-slate-400">
+                      Double-click to finish polygon
+                    </span>
+                    <span className="text-slate-300">•</span>
+                    <span className="text-[10px] text-slate-400">
+                      Right-click to cancel
+                    </span>
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
+              )}
+            </div>
+          )}
 
-        {/* Live Measurements panel — visible once measuring has started */}
-        {scaleFlowActive && scaleLocked && (
-          <LiveMeasurementsPanel
-            elements={elements}
+          {/* Live Measurements panel — visible once measuring has started */}
+          {scaleFlowActive && scaleLocked && (
+            <LiveMeasurementsPanel
+              elements={elements}
+              pendingVariants={concreteMeasurements}
+              scaleWhat={scaleWhat}
+              distanceUnit={distanceUnit}
+            />
+          )}
+        </div>
+
+        {/* ── Dialogs ── */}
+        <NewFolderDialog
+          open={newFolderOpen}
+          onOpenChange={setNewFolderOpen}
+          onConfirm={handleCreateFolder}
+        />
+
+        {/* 409 conflict — another live session exists for this project */}
+        <Dialog
+          open={!!sessionConflict}
+          onOpenChange={(v) => {
+            if (!v) setSessionConflict(null);
+          }}
+        >
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle className="text-sm font-bold">
+                Active Session Conflict
+              </DialogTitle>
+              <DialogDescription className="text-[13px] text-slate-500 pt-1">
+                There is already an active measurement session for this project.
+                You can resume that session (and navigate to its drawing) or
+                delete it and start a new one here.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <Button
+                variant="outline"
+                onClick={() => setSessionConflict(null)}
+              >
+                Cancel
+              </Button>
+              <Button variant="outline" onClick={handleResumeConflictSession}>
+                Resume Existing
+              </Button>
+              <Button
+                className="bg-amber-500 hover:bg-amber-600 text-white"
+                onClick={handleDeleteConflictAndCreate}
+              >
+                Delete &amp; Start Fresh
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <BBSQuestionModal
+          open={bbsModalStep === "question"}
+          answer={bbsAnswer}
+          onAnswerChange={setBbsAnswer}
+          onClose={handleBBSClose}
+          onSkip={handleBBSSkip}
+          onContinue={handleBBSContinue}
+        />
+
+        <BBSEntryModal
+          open={bbsModalStep === "entry"}
+          rows={bbsRows}
+          onRowChange={handleBBSRowChange}
+          onAddRow={handleAddBBSRow}
+          onCancel={handleBBSEntryCancel}
+          onSave={handleBBSSave}
+        />
+
+        <ScaleSetupModal
+          open={showScaleSetup}
+          measure={scaleWhat}
+          onMeasureChange={handleScaleSetupMeasureChange}
+          measureChoice={columnMeasureChoice}
+          onMeasureChoiceChange={setColumnMeasureChoice}
+          onCancel={handleScaleSetupCancel}
+          onYes={handleScaleSetupProceed}
+        />
+
+        <AssignItemsModal
+          open={assignModalOpen}
+          existingElements={elements}
+          pendingVariants={concreteMeasurements}
+          onClose={() => setAssignModalOpen(false)}
+          onContinue={handleAssignContinue}
+        />
+
+        <ConfirmAssignmentModal
+          open={confirmAssignOpen}
+          pendingVariants={concreteMeasurements}
+          targetElement={assigningElement}
+          onCancel={() => {
+            setConfirmAssignOpen(false);
+            setAssignModalOpen(true);
+          }}
+          onConfirm={handleConfirmMerge}
+        />
+
+        <AssignmentCompleteModal
+          open={assignCompleteOpen}
+          elementName={assignCompleteData?.elementName ?? ""}
+          addedCount={assignCompleteData?.addedCount ?? 0}
+          addedUnit={assignCompleteData?.addedUnit ?? "items"}
+          newTotal={assignCompleteData?.newTotal ?? 0}
+          onClose={() => {
+            setAssignCompleteOpen(false);
+            setAssignCompleteData(null);
+          }}
+          onViewElement={() => {
+            const el = elements.find(
+              (e) => e.id === assignCompleteData?.elementId,
+            );
+            setAssignCompleteOpen(false);
+            setAssignCompleteData(null);
+            if (el) handleElementClick(el);
+          }}
+        />
+
+        {/* Mount fresh each open so useState initializers fire with the latest variants */}
+        {createNewElOpen && (
+          <CreateNewElementModal
+            open={createNewElOpen}
             pendingVariants={concreteMeasurements}
-            scaleWhat={scaleWhat}
-            distanceUnit={distanceUnit}
+            measureType={scaleWhat}
+            onClose={() => setCreateNewElOpen(false)}
+            onUseExisting={() => {
+              setCreateNewElOpen(false);
+              setAssignModalOpen(true);
+            }}
+            onCreate={handleCreateNewEl}
           />
         )}
-      </div>
 
-      {/* ── Dialogs ── */}
-      <NewFolderDialog open={newFolderOpen} onOpenChange={setNewFolderOpen} onConfirm={handleCreateFolder} />
-
-      {/* 409 conflict — another live session exists for this project */}
-      <Dialog open={!!sessionConflict} onOpenChange={(v) => { if (!v) setSessionConflict(null); }}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle className="text-sm font-bold">Active Session Conflict</DialogTitle>
-            <DialogDescription className="text-[13px] text-slate-500 pt-1">
-              There is already an active measurement session for this project. You can resume
-              that session (and navigate to its drawing) or delete it and start a new one here.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex items-center justify-end gap-3 pt-2">
-            <Button variant="outline" onClick={() => setSessionConflict(null)}>Cancel</Button>
-            <Button variant="outline" onClick={handleResumeConflictSession}>Resume Existing</Button>
-            <Button
-              className="bg-amber-500 hover:bg-amber-600 text-white"
-              onClick={handleDeleteConflictAndCreate}
-            >
-              Delete &amp; Start Fresh
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <BBSQuestionModal
-        open={bbsModalStep === "question"}
-        answer={bbsAnswer}
-        onAnswerChange={setBbsAnswer}
-        onClose={handleBBSClose}
-        onSkip={handleBBSSkip}
-        onContinue={handleBBSContinue}
-      />
-
-      <BBSEntryModal
-        open={bbsModalStep === "entry"}
-        rows={bbsRows}
-        onRowChange={handleBBSRowChange}
-        onAddRow={handleAddBBSRow}
-        onCancel={handleBBSEntryCancel}
-        onSave={handleBBSSave}
-      />
-
-      <ScaleSetupModal
-        open={showScaleSetup}
-        measure={scaleWhat}
-        onMeasureChange={handleScaleSetupMeasureChange}
-        onCancel={handleScaleSetupCancel}
-        onYes={handleScaleSetupProceed}
-      />
-
-      <AssignItemsModal
-        open={assignModalOpen}
-        existingElements={elements}
-        pendingVariants={concreteMeasurements}
-        onClose={() => setAssignModalOpen(false)}
-        onContinue={handleAssignContinue}
-      />
-
-      <ConfirmAssignmentModal
-        open={confirmAssignOpen}
-        pendingVariants={concreteMeasurements}
-        targetElement={assigningElement}
-        onCancel={() => { setConfirmAssignOpen(false); setAssignModalOpen(true); }}
-        onConfirm={handleConfirmMerge}
-      />
-
-      <AssignmentCompleteModal
-        open={assignCompleteOpen}
-        elementName={assignCompleteData?.elementName ?? ""}
-        addedCount={assignCompleteData?.addedCount ?? 0}
-        addedUnit={assignCompleteData?.addedUnit ?? "items"}
-        newTotal={assignCompleteData?.newTotal ?? 0}
-        onClose={() => { setAssignCompleteOpen(false); setAssignCompleteData(null); }}
-        onViewElement={() => {
-          const el = elements.find((e) => e.id === assignCompleteData?.elementId);
-          setAssignCompleteOpen(false);
-          setAssignCompleteData(null);
-          if (el) handleElementClick(el);
-        }}
-      />
-
-      {/* Mount fresh each open so useState initializers fire with the latest variants */}
-      {createNewElOpen && (
-        <CreateNewElementModal
-          open={createNewElOpen}
-          pendingVariants={concreteMeasurements}
-          measureType={scaleWhat}
-          onClose={() => setCreateNewElOpen(false)}
-          onUseExisting={() => { setCreateNewElOpen(false); setAssignModalOpen(true); }}
-          onCreate={handleCreateNewEl}
-        />
-      )}
-
-      {/* Hidden PDF preloaders — eagerly resolve page count so sidebar shows all pages without
+        {/* Hidden PDF preloaders — eagerly resolve page count so sidebar shows all pages without
           requiring the user to click each file first. */}
-      <DrawingPreloader drawings={drawings} onPageCountResolved={handlePageCountResolved} />
-    </div>
+        <DrawingPreloader
+          drawings={drawings}
+          onPageCountResolved={handlePageCountResolved}
+        />
+      </div>
     </>
   );
 }

--- a/components/projects/workspace/components/CreateNewElementModal.tsx
+++ b/components/projects/workspace/components/CreateNewElementModal.tsx
@@ -120,16 +120,25 @@ function measureColumnMeta(tool: "count" | "length" | "area", unit: string) {
 
 function defaultCategoryFolder(measureType: string): string {
   const map: Record<string, string> = {
-    "Pile":                    "Substructure / Piles",
-    "Column in Foundation":    "Substructure / Foundations (Strip/Raft)",
-    "Ground Beam":             "Substructure / Ground Beams",
-    "Strip":                   "Substructure / Foundations (Strip/Raft)",
-    "Shear Wall":              "Superstructure / Shear Walls",
-    "Slabs":                   "Superstructure / Slabs",
-    "Roof Beams":              "Superstructure / Roof Structure",
-    "Roof Slab":               "Superstructure / Roof Structure",
-    "Roof Upstands / Parapet": "Architectural / Parapet Walls",
-    "Roof Gutter":             "External Works / Drainage",
+    "Piles":                              "Substructure / Piles",
+    "Pile Cap":                           "Substructure / Pile Caps",
+    "Ground Beam / Raft":                 "Substructure / Ground Beams",
+    "Column Base / Pad":                  "Substructure / Foundations (Strip/Raft)",
+    "Stud Column / Column in Foundation": "Substructure / Foundations (Strip/Raft)",
+    "Ground Floor Slab":                  "Substructure / Blinding Concrete",
+    "Blockwork on Foundation":            "Architectural / External Walls (Blockwork/Brick)",
+    "Columns":                            "Superstructure / Columns",
+    "Floor Beams":                        "Superstructure / Beams",
+    "Staircase":                          "Superstructure / Stairs",
+    "Upper Floor Slab":                   "Superstructure / Slabs",
+    "Lintel":                             "Architectural / Lintel",
+    "Blockwork":                          "Architectural / External Walls (Blockwork/Brick)",
+    "Roof":                               "Superstructure / Roof Structure",
+    "Windows":                            "Architectural / Windows",
+    "Doors":                              "Architectural / Doors",
+    "Floor Finishes":                     "Architectural / Floor Finishes (Paint/Tiles)",
+    "Wall Finishes":                      "Architectural / Internal Walls (Partition)",
+    "Ceiling Finishes":                   "Architectural / Ceiling Finishes",
   };
   return map[measureType] ?? "Substructure / Piles";
 }
@@ -174,13 +183,17 @@ export function CreateNewElementModal({
     () => defaultMeasurementUnit(activeTool),
   );
 
+  // No measurements yet — still allow creating the element as a zero-value shell
+  // (e.g. right after "+ New Element", before anything's been drawn).
   const [rows, setRows] = useState<PileRow[]>(() =>
-    pendingVariants.map((v) => ({
-      id: v.id,
-      name: v.tag || v.measureType,
-      count: colMeta.accessor(v),
-      volume: computeVolume(v.measureType, v.concreteFields, v.canvas),
-    })),
+    pendingVariants.length > 0
+      ? pendingVariants.map((v) => ({
+          id: v.id,
+          name: v.tag || v.measureType,
+          count: colMeta.accessor(v),
+          volume: computeVolume(v.measureType, v.concreteFields, v.canvas),
+        }))
+      : [{ id: "placeholder", name: measureType, count: "0", volume: "0" }],
   );
 
   function updateRow(id: string, field: keyof PileRow, value: string) {

--- a/components/projects/workspace/components/ElementDetailPanel.tsx
+++ b/components/projects/workspace/components/ElementDetailPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { X, Plus, Trash2 } from "lucide-react";
+import { Minus, Plus, Trash2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -32,11 +32,15 @@ export interface SaveMeasurementPayload {
 
 interface ElementDetailPanelProps {
   measure?: string;
+  /** Only meaningful when the category's tool is "choice" (Stud Column / Columns). */
+  measureChoice?: "count" | "area" | null;
   showRebarTab?: boolean;
   activeMeasureTool?: "length" | "area" | "count" | null;
   liveCount?: number;
   liveLength?: number;
   liveArea?: number;
+  /** Length drawn on canvas while the Rebar tab is active — fills "read" bar depths. */
+  liveRebarLength?: number | null;
   distanceUnit?: string;
   hasMeasurements?: boolean;
   activeColor?: string;
@@ -47,17 +51,22 @@ interface ElementDetailPanelProps {
   onSaveMeasurement?: (payload: SaveMeasurementPayload) => void;
   onFormChange?: (payload: SaveMeasurementPayload) => void;
   onResetMeasurements?: () => void;
+  onTabChange?: (tab: "concrete" | "rebar") => void;
+  /** Pointer handlers from the parent's drag logic — spread onto the header to make it a drag handle. */
+  dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ElementDetailPanel({
-  measure = "Pile",
+  measure = "Piles",
+  measureChoice = null,
   showRebarTab = false,
   activeMeasureTool = null,
   liveCount = 0,
   liveLength = 0,
   liveArea = 0,
+  liveRebarLength = null,
   distanceUnit = "Meters",
   hasMeasurements = false,
   activeColor,
@@ -68,27 +77,34 @@ export function ElementDetailPanel({
   onSaveMeasurement,
   onFormChange,
   onResetMeasurements,
+  onTabChange,
+  dragHandleProps,
 }: ElementDetailPanelProps) {
-  const cfg = ELEMENT_CONFIGS[measure] ?? ELEMENT_CONFIGS["Pile"];
+  const cfg = ELEMENT_CONFIGS[measure] ?? ELEMENT_CONFIGS["Piles"];
+  const rows =
+    cfg.tool === "choice" && cfg.rowsByChoice
+      ? cfg.rowsByChoice[measureChoice ?? "count"]
+      : cfg.rows;
   const [activeTab, setActiveTab] = useState<"concrete" | "rebar">("concrete");
   const [savedFeedback, setSavedFeedback] = useState(false);
 
   // ── Concrete form ───────────────────────────────────────────────────────────
 
-  const buildDefaultFields = (m: string): Record<string, string> => {
-    const c = ELEMENT_CONFIGS[m] ?? ELEMENT_CONFIGS["Pile"];
+  const buildDefaultFields = (m: string, choice: "count" | "area" | null): Record<string, string> => {
+    const c = ELEMENT_CONFIGS[m] ?? ELEMENT_CONFIGS["Piles"];
+    const r = c.tool === "choice" && c.rowsByChoice ? c.rowsByChoice[choice ?? "count"] : c.rows;
     const init: Record<string, string> = { tag: "" };
-    c.rows.forEach((row) => row.fields.forEach((f) => { init[f.key] = f.defaultValue; }));
+    r.forEach((row) => row.fields.forEach((f) => { init[f.key] = f.defaultValue; }));
     return init;
   };
 
   const [fieldValues, setFieldValues] = useState<Record<string, string>>(
-    () => buildDefaultFields(measure),
+    () => buildDefaultFields(measure, measureChoice),
   );
 
   useEffect(() => {
-    setFieldValues(buildDefaultFields(measure));
-  }, [measure]);
+    setFieldValues(buildDefaultFields(measure, measureChoice));
+  }, [measure, measureChoice]);
 
   function setField(key: string, value: string) {
     setFieldValues((prev) => ({ ...prev, [key]: value }));
@@ -106,6 +122,14 @@ export function ElementDetailPanel({
   const [inclStirrupsLocal, setInclStirrupsLocal] = useState(true);
   const [stirrupSize, setStirrupSize] = useState("Y8");
   const [stirrupSpacing, setStirrupSpacing] = useState("0");
+
+  // "Read from drawing": one length drawn on canvas fills every bar row's depth.
+  useEffect(() => {
+    if (rebarMethod !== "read" || liveRebarLength == null) return;
+    const depth = liveRebarLength.toFixed(2);
+    setMainBars((prev) => prev.map((b) => ({ ...b, depth })));
+    setAdditionBars((prev) => prev.map((b) => ({ ...b, depth })));
+  }, [liveRebarLength, rebarMethod]);
 
   function resetRebarToDefaults() {
     setRebarMethod("manual");
@@ -152,7 +176,7 @@ export function ElementDetailPanel({
 
   const concreteFormFilled =
     fieldValues.tag.trim() !== "" ||
-    cfg.rows.some((row) =>
+    rows.some((row) =>
       row.fields.some((f) => {
         if (f.type === "select") return false;
         const v = fieldValues[f.key] ?? "";
@@ -240,9 +264,10 @@ export function ElementDetailPanel({
     onApplyAndContinue();
 
     // Reset both forms to defaults for the next variant
-    setFieldValues(buildDefaultFields(measure));
+    setFieldValues(buildDefaultFields(measure, measureChoice));
     resetRebarToDefaults();
     setActiveTab("concrete");
+    onTabChange?.("concrete");
 
     setSavedFeedback(true);
     setTimeout(() => setSavedFeedback(false), 2000);
@@ -251,15 +276,21 @@ export function ElementDetailPanel({
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
-    <div className="w-[290px] shrink-0 bg-white border-l border-slate-200 flex flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 shrink-0">
+    <div className="w-full h-full bg-white flex flex-col overflow-hidden">
+      {/* Header — also the drag handle when floating */}
+      <div
+        {...dragHandleProps}
+        style={{ touchAction: "none", ...dragHandleProps?.style }}
+        className="flex items-center justify-between px-4 py-3 border-b border-slate-200 shrink-0 cursor-grab active:cursor-grabbing"
+      >
         <span className="text-sm font-bold text-slate-800 uppercase tracking-wider">{measure}</span>
         <button
           onClick={onClose}
+          onPointerDown={(e) => e.stopPropagation()}
+          title="Minimize"
           className="w-6 h-6 flex items-center justify-center rounded hover:bg-slate-100 text-slate-400 hover:text-slate-600 transition-colors"
         >
-          <X className="w-3.5 h-3.5" />
+          <Minus className="w-3.5 h-3.5" />
         </button>
       </div>
 
@@ -268,7 +299,7 @@ export function ElementDetailPanel({
         {(showRebarTab ? (["concrete", "rebar"] as const) : (["concrete"] as const)).map((tab) => (
           <button
             key={tab}
-            onClick={() => setActiveTab(tab)}
+            onClick={() => { setActiveTab(tab); onTabChange?.(tab); }}
             className={`flex-1 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
               activeTab === tab
                 ? "text-amber-600 border-b-2 border-amber-500"
@@ -326,7 +357,7 @@ export function ElementDetailPanel({
               )}
             </div>
 
-            {cfg.rows.map((row, i) => (
+            {rows.map((row, i) => (
               <div key={i} className="space-y-2">
                 {row.sectionLabel && (
                   <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">

--- a/components/projects/workspace/components/ScaleSetupModal.tsx
+++ b/components/projects/workspace/components/ScaleSetupModal.tsx
@@ -9,21 +9,28 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { SCALE_MEASURE_OPTIONS } from "./constants";
+import { SCALE_MEASURE_OPTIONS, ELEMENT_CONFIGS } from "./constants";
 
 export function ScaleSetupModal({
   open,
   measure,
   onMeasureChange,
+  measureChoice,
+  onMeasureChoiceChange,
   onCancel,
   onYes,
 }: {
   open: boolean;
   measure: string;
   onMeasureChange: (v: string) => void;
+  measureChoice: "count" | "area" | null;
+  onMeasureChoiceChange: (v: "count" | "area") => void;
   onCancel: () => void;
   onYes: () => void;
 }) {
+  const isChoiceCategory = ELEMENT_CONFIGS[measure]?.tool === "choice";
+  const canProceed = !isChoiceCategory || measureChoice !== null;
+
   return (
     <Dialog open={open} onOpenChange={(v) => { if (!v) onCancel(); }}>
       <DialogContent className="max-w-sm">
@@ -58,8 +65,36 @@ export function ScaleSetupModal({
             </Select>
           </div>
 
+          {isChoiceCategory && (
+            <div className="w-full space-y-1.5">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">
+                How do you want to measure this?
+              </p>
+              <div className="flex items-center gap-3 w-full">
+                {(["count", "area"] as const).map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => onMeasureChoiceChange(c)}
+                    className={`flex-1 py-2 rounded-lg border text-sm font-semibold capitalize transition-colors ${
+                      measureChoice === c
+                        ? "bg-amber-500 border-amber-500 text-white"
+                        : "bg-white border-slate-200 text-slate-500 hover:border-slate-300"
+                    }`}
+                  >
+                    {c}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="flex items-center gap-3 w-full">
-            <Button onClick={onYes} className="flex-1 bg-amber-500 hover:bg-amber-600 text-white">
+            <Button
+              onClick={onYes}
+              disabled={!canProceed}
+              className="flex-1 bg-amber-500 hover:bg-amber-600 text-white disabled:opacity-40"
+            >
               Yes, I want to Scale
             </Button>
             <Button variant="outline" onClick={onCancel} className="flex-1">

--- a/components/projects/workspace/components/constants.ts
+++ b/components/projects/workspace/components/constants.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from "react";
-import { Ruler, Pentagon, Hash, Type, Undo2, Redo2 } from "lucide-react";
+import { Type, Undo2, Redo2 } from "lucide-react";
 import type { DrawingCategory } from "@/store/slices/manualWizardSlice";
-import type { ToolId, ElementConcreteConfig } from "./types";
+import type { ToolId, ElementConcreteConfig, ConcreteRowDef } from "./types";
 
 export const PALETTE = [
   "#ef4444",
@@ -31,9 +31,6 @@ export const TOOLS: {
   label: string;
   description: string;
 }[] = [
-  { id: "length", icon: Ruler, label: "Length", description: "Measure linear distances on the drawing" },
-  { id: "area", icon: Pentagon, label: "Area", description: "Measure polygon areas on the drawing" },
-  { id: "count", icon: Hash, label: "Count", description: "Count items and elements on the drawing" },
   { id: "text", icon: Type, label: "Text", description: "Add text annotations to the drawing" },
   { id: "undo", icon: Undo2, label: "Undo", description: "Undo the last action" },
   { id: "redo", icon: Redo2, label: "Redo", description: "Redo the last undone action" },
@@ -41,21 +38,54 @@ export const TOOLS: {
 
 export const BAR_SIZE_OPTIONS = ["Y8", "Y10", "Y12", "Y16", "Y20", "Y25", "Y32"];
 
+// The real length measured on the drawing for a Lintel always gets this added
+// on top before it's used as the BOQ quantity (door opening + bearing on each side).
+export const LINTEL_LENGTH_BONUS_M = 0.3;
+
+// ─── "What do you want to measure?" category list ──────────────────────────────
+// Each category drives which canvas tool auto-activates (see ELEMENT_CONFIGS below).
+// "Stud Column / Column in Foundation" and "Columns" are dual-mode: the user picks
+// Count or Area right after choosing the category.
+
 export const SCALE_MEASURE_OPTIONS = [
-  "Pile",
-  "Column in Foundation",
-  "Ground Beam",
-  "Strip",
-  "Shear Wall",
-  "Slabs",
-  "Roof Beams",
-  "Roof Slab",
-  "Roof Upstands / Parapet",
-  "Roof Gutter",
+  "Piles",
+  "Pile Cap",
+  "Ground Beam / Raft",
+  "Column Base / Pad",
+  "Stud Column / Column in Foundation",
+  "Ground Floor Slab",
+  "Blockwork on Foundation",
+  "Columns",
+  "Floor Beams",
+  "Staircase",
+  "Upper Floor Slab",
+  "Lintel",
+  "Blockwork",
+  "Roof",
+  "Windows",
+  "Doors",
+  "Floor Finishes",
+  "Wall Finishes",
+  "Ceiling Finishes",
+];
+
+const countLWH: ConcreteRowDef[] = [
+  {
+    fields: [
+      { key: "length", label: "Length (m)", defaultValue: "0" },
+      { key: "width", label: "Width (m)", defaultValue: "0" },
+    ],
+  },
+  { fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] },
+];
+
+const areaHeightOnly: ConcreteRowDef[] = [
+  { fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] },
 ];
 
 export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
-  Pile: {
+  Piles: {
+    tool: "count",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
     tagLabel: "Tag this Pile as:",
     tagPlaceholder: "e.g. P1",
@@ -77,29 +107,18 @@ export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
       },
     ],
   },
-  "Column in Foundation": {
+  "Pile Cap": {
+    tool: "area",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this Column as:",
-    tagPlaceholder: "e.g. C1",
-    measureLabel: "Counts",
-    measureUnit: "",
+    tagLabel: "Tag this Pile Cap as:",
+    tagPlaceholder: "e.g. PC1",
+    measureLabel: "Area",
+    measureUnit: "m²",
     mockMeasureValue: "0",
-    rows: [
-      {
-        fields: [
-          { key: "shape", label: "Shape", defaultValue: "Square", type: "select", options: ["Circular", "Square", "Rectangular"] },
-          { key: "depth", label: "Depth (m)", defaultValue: "0" },
-        ],
-      },
-      {
-        fields: [
-          { key: "width", label: "Width (m)", defaultValue: "0" },
-          { key: "breadth", label: "Breadth (m)", defaultValue: "0" },
-        ],
-      },
-    ],
+    rows: [{ fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }] }],
   },
-  "Ground Beam": {
+  "Ground Beam / Raft": {
+    tool: "length",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
     tagLabel: "Tag this beam as:",
     tagPlaceholder: "e.g. BM1",
@@ -113,64 +132,65 @@ export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
           { key: "depth", label: "Depth (m)", defaultValue: "0" },
         ],
       },
-      {
-        fields: [
-          { key: "quantity", label: "Quantity (identical Beams)", defaultValue: "0" },
-        ],
-      },
     ],
   },
-  Strip: {
-    sectionHeader: "CONCRETE FOOTING (FROM MEASUREMENT)",
-    tagLabel: "Tag this Strip as:",
-    tagPlaceholder: "e.g. #1",
-    measureLabel: "Length",
-    measureUnit: "m",
-    mockMeasureValue: "0",
-    rows: [
-      {
-        sectionLabel: "EXCAVATION",
-        fields: [{ key: "excavationDepth", label: "Depth (m)", defaultValue: "0" }],
-      },
-      {
-        sectionLabel: "BLOCKWORK",
-        fields: [{ key: "blockworkHeight", label: "Height (m)", defaultValue: "0" }],
-      },
-    ],
-  },
-  "Shear Wall": {
+  "Column Base / Pad": {
+    tool: "area",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this wall as:",
-    tagPlaceholder: "e.g. SW1",
-    measureLabel: "Length",
-    measureUnit: "m",
+    tagLabel: "Tag this Base as:",
+    tagPlaceholder: "e.g. PD1",
+    measureLabel: "Area",
+    measureUnit: "m²",
     mockMeasureValue: "0",
-    rows: [
-      {
-        fields: [
-          { key: "width", label: "Width (m)", defaultValue: "0" },
-          { key: "height", label: "Height (m)", defaultValue: "0" },
-        ],
-      },
-    ],
+    rows: [{ fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }] }],
   },
-  Slabs: {
+  "Stud Column / Column in Foundation": {
+    tool: "choice",
+    sectionHeader: "CONCRETE (FROM MEASUREMENT)",
+    tagLabel: "Tag this Column as:",
+    tagPlaceholder: "e.g. SC1",
+    measureLabel: "Counts",
+    measureUnit: "",
+    mockMeasureValue: "0",
+    rows: countLWH,
+    rowsByChoice: { count: countLWH, area: areaHeightOnly },
+  },
+  "Ground Floor Slab": {
+    tool: "area",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
     tagLabel: "Tag this Slab as:",
-    tagPlaceholder: "e.g. SBO1",
+    tagPlaceholder: "e.g. GFS1",
     measureLabel: "Area",
     measureUnit: "m²",
     mockMeasureValue: "0",
-    rows: [
-      {
-        fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }],
-      },
-    ],
+    rows: [{ fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }] }],
   },
-  "Roof Beams": {
+  "Blockwork on Foundation": {
+    tool: "length",
+    sectionHeader: "BLOCKWORK (FROM MEASUREMENT)",
+    tagLabel: "Tag this run as:",
+    tagPlaceholder: "e.g. BW-F1",
+    measureLabel: "Length",
+    measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [{ fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] }],
+  },
+  Columns: {
+    tool: "choice",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this Roof Beam as:",
-    tagPlaceholder: "e.g. RB",
+    tagLabel: "Tag this Column as:",
+    tagPlaceholder: "e.g. C1",
+    measureLabel: "Counts",
+    measureUnit: "",
+    mockMeasureValue: "0",
+    rows: countLWH,
+    rowsByChoice: { count: countLWH, area: areaHeightOnly },
+  },
+  "Floor Beams": {
+    tool: "length",
+    sectionHeader: "CONCRETE (FROM MEASUREMENT)",
+    tagLabel: "Tag this beam as:",
+    tagPlaceholder: "e.g. FB1",
     measureLabel: "Length",
     measureUnit: "m",
     mockMeasureValue: "0",
@@ -183,50 +203,119 @@ export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
       },
     ],
   },
-  "Roof Slab": {
+  Staircase: {
+    tool: "length",
     sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this Roof Slab as:",
-    tagPlaceholder: "e.g. RS",
+    tagLabel: "Tag this Staircase as:",
+    tagPlaceholder: "e.g. ST1",
+    measureLabel: "Length",
+    measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [],
+  },
+  "Upper Floor Slab": {
+    tool: "area",
+    sectionHeader: "CONCRETE (FROM MEASUREMENT)",
+    tagLabel: "Tag this Slab as:",
+    tagPlaceholder: "e.g. UFS1",
     measureLabel: "Area",
     measureUnit: "m²",
     mockMeasureValue: "0",
-    rows: [
-      {
-        fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }],
-      },
-    ],
+    rows: [{ fields: [{ key: "thickness", label: "Thickness (m)", defaultValue: "0" }] }],
   },
-  "Roof Upstands / Parapet": {
-    sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this Roof Upstands / Parapet as:",
-    tagPlaceholder: "e.g. RUP",
+  Lintel: {
+    tool: "length",
+    sectionHeader: "LINTEL (FROM MEASUREMENT)",
+    tagLabel: "Tag this Lintel as:",
+    tagPlaceholder: "e.g. L1",
+    measureLabel: "Length (door opening + 300mm)",
+    measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [],
+  },
+  Blockwork: {
+    tool: "length",
+    sectionHeader: "BLOCKWORK (FROM MEASUREMENT)",
+    tagLabel: "Tag this run as:",
+    tagPlaceholder: "e.g. BW1",
     measureLabel: "Length",
     measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [{ fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] }],
+  },
+  Roof: {
+    tool: "length",
+    sectionHeader: "ROOF (FROM MEASUREMENT)",
+    tagLabel: "Tag this run as:",
+    tagPlaceholder: "e.g. RF1",
+    measureLabel: "Length",
+    measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [],
+  },
+  Windows: {
+    tool: "count",
+    sectionHeader: "WINDOWS (FROM MEASUREMENT)",
+    tagLabel: "Tag this Window as:",
+    tagPlaceholder: "e.g. W1",
+    measureLabel: "Counts",
+    measureUnit: "",
     mockMeasureValue: "0",
     rows: [
       {
         fields: [
+          { key: "width", label: "Width (m)", defaultValue: "0" },
           { key: "height", label: "Height (m)", defaultValue: "0" },
-          { key: "thickness", label: "Thickness (m)", defaultValue: "0" },
         ],
       },
     ],
   },
-  "Roof Gutter": {
-    sectionHeader: "CONCRETE (FROM MEASUREMENT)",
-    tagLabel: "Tag this Roof Gutter as:",
-    tagPlaceholder: "e.g. RG",
-    measureLabel: "Length",
-    measureUnit: "m",
+  Doors: {
+    tool: "count",
+    sectionHeader: "DOORS (FROM MEASUREMENT)",
+    tagLabel: "Tag this Door as:",
+    tagPlaceholder: "e.g. D1",
+    measureLabel: "Counts",
+    measureUnit: "",
     mockMeasureValue: "0",
     rows: [
       {
         fields: [
           { key: "width", label: "Width (m)", defaultValue: "0" },
-          { key: "depth", label: "Depth (m)", defaultValue: "0" },
+          { key: "height", label: "Height (m)", defaultValue: "0" },
         ],
       },
     ],
+  },
+  "Floor Finishes": {
+    tool: "area",
+    sectionHeader: "FINISHES (FROM MEASUREMENT)",
+    tagLabel: "Tag this area as:",
+    tagPlaceholder: "e.g. FF1",
+    measureLabel: "Area",
+    measureUnit: "m²",
+    mockMeasureValue: "0",
+    rows: [],
+  },
+  "Wall Finishes": {
+    tool: "length",
+    sectionHeader: "FINISHES (FROM MEASUREMENT)",
+    tagLabel: "Tag this run as:",
+    tagPlaceholder: "e.g. WF1",
+    measureLabel: "Length",
+    measureUnit: "m",
+    mockMeasureValue: "0",
+    rows: [{ fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] }],
+  },
+  "Ceiling Finishes": {
+    tool: "area",
+    sectionHeader: "FINISHES (FROM MEASUREMENT)",
+    tagLabel: "Tag this area as:",
+    tagPlaceholder: "e.g. CF1",
+    measureLabel: "Area",
+    measureUnit: "m²",
+    mockMeasureValue: "0",
+    rows: [],
   },
 };
 

--- a/components/projects/workspace/components/types.ts
+++ b/components/projects/workspace/components/types.ts
@@ -48,6 +48,9 @@ export interface ConcreteRowDef {
 }
 
 export interface ElementConcreteConfig {
+  /** Which canvas tool auto-activates for this category. "choice" means the user
+   *  picks Count or Area right after selecting the category (see rowsByChoice). */
+  tool: "count" | "length" | "area" | "choice";
   sectionHeader: string;
   tagLabel: string;
   tagPlaceholder: string;
@@ -55,6 +58,8 @@ export interface ElementConcreteConfig {
   measureUnit: string;
   mockMeasureValue: string;
   rows: ConcreteRowDef[];
+  /** Only present when tool === "choice" — field rows per chosen tool. */
+  rowsByChoice?: { count: ConcreteRowDef[]; area: ConcreteRowDef[] };
 }
 
 // ─── Created element ──────────────────────────────────────────────────────────
@@ -88,47 +93,39 @@ export function computeVolume(
   const pi = Math.PI;
 
   switch (measureType) {
-    case "Pile": {
+    case "Piles": {
       const depth = n("depth");
       const diameter = n("diameter");
       const radius = diameter / 2;
       const vol = pi * radius * radius * depth;
       return vol > 0 ? vol.toFixed(3) : "0";
     }
-    case "Column in Foundation":
-    case "Shear Wall": {
-      const shape = fields["shape"] ?? "Square";
-      const depth = n("depth");
-      const height = n("height");
-      const actualDepth = depth || height;
-      if (shape === "Circular") {
-        const diameter = n("diameter");
-        const vol = pi * Math.pow(diameter / 2, 2) * actualDepth;
+    case "Stud Column / Column in Foundation":
+    case "Columns": {
+      // Choice categories: count → length × width × height, area → traced area × height.
+      if (canvas.tool === "area") {
+        const height = n("height");
+        const vol = canvas.area * height;
         return vol > 0 ? vol.toFixed(3) : "0";
       }
+      const length = n("length");
       const width = n("width");
-      const breadth = n("breadth") || width;
-      const vol = width * breadth * actualDepth;
+      const height = n("height");
+      const vol = length * width * height;
       return vol > 0 ? vol.toFixed(3) : "0";
     }
-    case "Ground Beam":
-    case "Roof Beams":
-    case "Roof Upstands / Parapet":
-    case "Roof Gutter": {
+    case "Ground Beam / Raft":
+    case "Floor Beams": {
       const width = n("width");
-      const depth = n("depth") || n("height");
+      const depth = n("depth");
       const length = canvas.length;
       const vol = width * depth * length;
       return vol > 0 ? vol.toFixed(3) : "0";
     }
-    case "Strip": {
-      const excavDepth = n("excavationDepth");
-      const length = canvas.length;
-      const vol = excavDepth * length;
-      return vol > 0 ? vol.toFixed(3) : "0";
-    }
-    case "Slabs":
-    case "Roof Slab": {
+    case "Pile Cap":
+    case "Column Base / Pad":
+    case "Ground Floor Slab":
+    case "Upper Floor Slab": {
       const thickness = n("thickness");
       const area = canvas.area;
       const vol = thickness * area;

--- a/components/projects/workspace/workspaceSession.ts
+++ b/components/projects/workspace/workspaceSession.ts
@@ -89,6 +89,11 @@ export interface WorkspaceSession {
   createdElements: CreatedElement[];
   elementAssignments: WsElementAssignment[];
   drawings: SessionDrawing[];
+  /** Floating Element Detail Panel — position relative to the canvas viewport, and collapsed state */
+  elementPanelPos: { x: number; y: number } | null;
+  elementPanelCollapsed: boolean;
+  /** Left workspace sidebar — collapses to a small floating header, canvas fills the freed space */
+  sidebarCollapsed: boolean;
 }
 
 // ─── Storage helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
…le UX fixes

Tool selection now derives from a 19-item BOQ category list instead of manual Length/Area/Count buttons, chained through BBS then Scale Setup then the real Create Element modal so new elements are backend-persisted and visible in the sidebar immediately.

Scale application now awaits backend confirmation before unlocking drawing, with the calibration bar split into distinct pre-apply, post-apply, and locked states.

The Element Detail Panel is now a draggable, collapsible floating panel over the canvas instead of a fixed sidebar. The left workspace sidebar collapses to a small floating header, letting the canvas fill the freed space.

Added mouse-wheel and trackpad-pinch zoom, and repositioned the zoom controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added expanded measurement categories and support for count- or area-based choices.
  - Improved workspace hydration, session switching, undo/redo, zoom, and element visibility across sessions.
  - Added draggable, collapsible element details and workspace sidebar panels.
  - Enhanced auto-save for measurement variants, reinforcement marks, and restored sessions.
  - Added clearer scale setup validation and BOQ finalization error messages.

- **Bug Fixes**
  - Improved handling of session conflicts, assignments, saved drawings, and scale updates.
  - Fixed concrete and reinforcement measurements being incorrectly combined.
  - Added placeholder rows when creating elements without pending measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->