### PR TITLE
fix: scope wheel zoom, fix panel overflow and live measurement sync, …

### DIFF
--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -274,6 +274,8 @@ function toBackendElementType(measureType: string): string {
     // Blockwork has no dedicated backend type yet — closest existing match is "wall".
     Blockwork: "wall",
     "Blockwork on Foundation": "wall",
+    "External Blockwork": "wall",
+    "Internal Blockwork": "wall",
   };
   return map[measureType] ?? measureType.toLowerCase().replace(/[\s/]+/g, "_");
 }
@@ -491,6 +493,11 @@ export function ProjectWorkspaceView({
   );
   // Length drawn on canvas while the Rebar tab is active, passed down to auto-fill bar depths.
   const [rebarDrawnLength, setRebarDrawnLength] = useState<number | null>(null);
+  // Blockwork-only: External/Internal are independent elements, not tab views of
+  // the same one. Defaults to External whenever a Blockwork round starts fresh.
+  const [blockworkSide, setBlockworkSide] = useState<"external" | "internal">(
+    "external",
+  );
 
   // ── Backend-owned state — start empty, populated by Phase 2 hydration ────────
   const [scaleFlowActive, setScaleFlowActive] = useState(false);
@@ -596,14 +603,13 @@ export function ProjectWorkspaceView({
     null,
   );
 
-  // ── Session totals — accumulate across files until Apply & Continue ───────────
+  // ── Round totals — derived from actual canvas marks, never a drifting counter ──
   // Left sidebar  = per-page totals (lengthTotal / countTotal / areaTotal below)
-  // Right sidebar = session totals (what you've measured this round across all files)
-  const [sessionTotals, setSessionTotals] = useState({
-    count: 0,
-    length: 0,
-    area: 0,
-  });
+  // Right panel   = current-round totals: marks not yet "claimed" by a finished
+  // round (Apply & Continue, +New Element, Blockwork side switch, hydration).
+  // Deriving straight from measurementHook.state.measurements means undo/redo can
+  // never desync it, unlike an incrementing counter that only ever counted up.
+  const [claimedMarkIds, setClaimedMarkIds] = useState<Set<string>>(new Set());
 
   // ── Per-page measurement state (persisted to localStorage) ───────────────────
   const measurementHook = useCanvasMeasurements(
@@ -614,6 +620,34 @@ export function ProjectWorkspaceView({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const selectedDrawing =
     drawings.find((d) => d.id === selectedDrawingId) ?? null;
+
+  // Current-round totals: sum of marks that aren't yet claimed by a finished
+  // round and aren't rebar-tab reference lengths. Recomputed from the actual
+  // mark list on every render, so undo/redo can never leave it stale.
+  const sessionTotals = useMemo(() => {
+    let count = 0,
+      length = 0,
+      area = 0;
+    for (const m of measurementHook.state.measurements) {
+      if (claimedMarkIds.has(m.id) || rebarMarkIds.current.has(m.id)) continue;
+      if (m.type === "count") count++;
+      else if (m.type === "length") length += m.realLength;
+      else if (m.type === "area") area += m.realArea;
+    }
+    return { count, length, area };
+  }, [measurementHook.state.measurements, claimedMarkIds]);
+
+  // Marks the marks currently on canvas as "belonging to a finished round" so
+  // the next round's live totals start fresh at zero without touching the
+  // drawing itself — used by Apply & Continue, +New Element, and Blockwork
+  // side switching.
+  function claimCurrentMarks() {
+    setClaimedMarkIds((prev) => {
+      const next = new Set(prev);
+      for (const m of measurementHook.state.measurements) next.add(m.id);
+      return next;
+    });
+  }
 
   // ── On mount: wipe stale backend-owned keys from localStorage AND live state ──
   // Scale, elements, and variants are now sourced from the backend session.
@@ -651,6 +685,8 @@ export function ProjectWorkspaceView({
     setActiveTool(null);
     setElements([]);
     setConcreteMeasurements([]);
+    setClaimedMarkIds(new Set());
+    rebarMarkIds.current = new Set();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
@@ -795,6 +831,15 @@ export function ProjectWorkspaceView({
         calibPts: null,
         measurements,
       });
+      // These marks belong to already-saved elements from a prior round —
+      // exclude them from the next fresh round's live totals.
+      if (measurements.length > 0) {
+        setClaimedMarkIds((prev) => {
+          const next = new Set(prev);
+          for (const m of measurements) next.add(m.id);
+          return next;
+        });
+      }
     }
   }, [
     activeSessionData,
@@ -928,7 +973,7 @@ export function ProjectWorkspaceView({
       .filter((id) => !rebarMarkIds.current.has(id));
     const variant: WsConcreteMeasurement = {
       id: currentVariantId.current,
-      measureType: scaleWhat,
+      measureType: effectiveMeasureType,
       tag: payload?.tag ?? "",
       concreteFields: payload?.concreteFields ?? {},
       rebar: payload?.rebar ?? null,
@@ -1024,6 +1069,18 @@ export function ProjectWorkspaceView({
     return cfg.tool;
   }, [scaleWhat, columnMeasureChoice]);
 
+  const isBlockworkCategory =
+    ELEMENT_CONFIGS[scaleWhat]?.blockworkSides === true;
+
+  // External/Internal Blockwork are independent elements — this is the name
+  // actually used for measureType, backend type mapping, and category folder,
+  // wherever scaleWhat would normally be used for those purposes.
+  const effectiveMeasureType = isBlockworkCategory
+    ? blockworkSide === "external"
+      ? "External Blockwork"
+      : "Internal Blockwork"
+    : scaleWhat;
+
   // While the Rebar tab is active, the canvas always draws lengths (rebar runs),
   // regardless of what tool the concrete measurement uses. Switching back to the
   // Concrete tab restores the category's own tool.
@@ -1044,6 +1101,17 @@ export function ProjectWorkspaceView({
     if (tab === "concrete") setRebarDrawnLength(null);
   }
 
+  // External/Internal Blockwork are independent elements — switching starts a
+  // fresh round (live length back to zero, new variant) without touching
+  // whatever's already drawn on the sheet.
+  function handleBlockworkSideChange(side: "external" | "internal") {
+    if (side === blockworkSide) return;
+    setBlockworkSide(side);
+    claimCurrentMarks();
+    currentVariantId.current = crypto.randomUUID();
+    lastFormPayload.current = null;
+  }
+
   function handleAddNewElement() {
     // Start a fresh measurement round so this doesn't overwrite whatever variant
     // was previously being drawn.
@@ -1052,7 +1120,8 @@ export function ProjectWorkspaceView({
     setColumnMeasureChoice(null);
     setElementPanelTab("concrete");
     setRebarDrawnLength(null);
-    setSessionTotals({ count: 0, length: 0, area: 0 });
+    setBlockworkSide("external");
+    claimCurrentMarks();
     setLiveDrawingLength(null);
     setPendingTool(null);
     setShowScaleSetup(true);
@@ -1219,8 +1288,14 @@ export function ProjectWorkspaceView({
 
   // "Yes, I want to Scale" — category is chosen, next step is the BBS question.
   // Scale flow itself only activates once BBS is answered (see activateScaleFlow).
+  // Blockwork has no rebar involved at all, so it skips BBS entirely.
   function handleScaleSetupProceed() {
     setShowScaleSetup(false);
+    if (isBlockworkCategory) {
+      setShowRebarTab(false);
+      activateScaleFlow();
+      return;
+    }
     setBbsModalStep("question");
   }
   function handleScaleSetupCancel() {
@@ -1237,6 +1312,7 @@ export function ProjectWorkspaceView({
     setShowElementPanel(true);
     setShowCalibrationBar(true);
     setPendingTool(null);
+    setBlockworkSide("external");
 
     setActiveTool(concreteToolForCategory);
     setCountModeActive(concreteToolForCategory === "count");
@@ -1376,7 +1452,7 @@ export function ProjectWorkspaceView({
     // already persisted, rather than creating a duplicate with a new UUID.
     const variant: WsConcreteMeasurement = {
       id: currentVariantId.current,
-      measureType: scaleWhat,
+      measureType: effectiveMeasureType,
       tag: payload.tag,
       concreteFields: payload.concreteFields,
       rebar: payload.rebar,
@@ -1648,22 +1724,12 @@ export function ProjectWorkspaceView({
     measurementHook.addMeasurement(m);
 
     // Rebar tab: the drawn length fills bar depths in the panel instead of
-    // contributing to this element's own concrete quantity.
+    // contributing to this element's own concrete quantity. sessionTotals is
+    // derived from measurementHook.state.measurements, so no manual increment
+    // is needed for the concrete case — it updates automatically on re-render.
     if (elementPanelTab === "rebar" && m.type === "length") {
       rebarMarkIds.current.add(m.id);
       setRebarDrawnLength(m.realLength);
-      return;
-    }
-
-    if (m.type === "count") {
-      setSessionTotals((prev) => ({ ...prev, count: prev.count + 1 }));
-    } else if (m.type === "length") {
-      setSessionTotals((prev) => ({
-        ...prev,
-        length: prev.length + m.realLength,
-      }));
-    } else if (m.type === "area") {
-      setSessionTotals((prev) => ({ ...prev, area: prev.area + m.realArea }));
     }
   }
 
@@ -1880,7 +1946,7 @@ export function ProjectWorkspaceView({
   // Canvas lines are permanent records; only the session totals reset.
 
   function handleSessionReset() {
-    setSessionTotals({ count: 0, length: 0, area: 0 });
+    claimCurrentMarks();
     setLiveDrawingLength(null);
     setRebarDrawnLength(null);
     setElementPanelTab("concrete");
@@ -2718,6 +2784,7 @@ export function ProjectWorkspaceView({
               {showElementPanel && (
                 <div
                   ref={elementPanelRef}
+                  onWheel={(e) => e.stopPropagation()}
                   className={`absolute z-20 ${elementPanelPos ? "" : "right-6 top-4"}`}
                   style={
                     elementPanelPos
@@ -2745,7 +2812,7 @@ export function ProjectWorkspaceView({
                       )}
                     </button>
                   ) : (
-                    <div className="w-[290px] rounded-xl shadow-xl border border-slate-200 overflow-hidden animate-in fade-in zoom-in-95 duration-200 origin-top-right">
+                    <div className="w-[290px] max-h-[70vh] flex flex-col rounded-xl shadow-xl border border-slate-200 overflow-hidden animate-in fade-in zoom-in-95 duration-200 origin-top-right">
                       <ElementDetailPanel
                         measure={scaleWhat}
                         measureChoice={columnMeasureChoice}
@@ -2778,6 +2845,8 @@ export function ProjectWorkspaceView({
                         onFormChange={handleAutoSave}
                         onResetMeasurements={handleSessionReset}
                         onTabChange={handleElementPanelTabChange}
+                        blockworkSide={blockworkSide}
+                        onBlockworkSideChange={handleBlockworkSideChange}
                         dragHandleProps={{
                           onPointerDown: handlePanelDragStart,
                           onPointerMove: handlePanelDragMove,
@@ -3009,7 +3078,7 @@ export function ProjectWorkspaceView({
             <LiveMeasurementsPanel
               elements={elements}
               pendingVariants={concreteMeasurements}
-              scaleWhat={scaleWhat}
+              scaleWhat={effectiveMeasureType}
               distanceUnit={distanceUnit}
             />
           )}
@@ -3132,7 +3201,7 @@ export function ProjectWorkspaceView({
           <CreateNewElementModal
             open={createNewElOpen}
             pendingVariants={concreteMeasurements}
-            measureType={scaleWhat}
+            measureType={effectiveMeasureType}
             onClose={() => setCreateNewElOpen(false)}
             onUseExisting={() => {
               setCreateNewElOpen(false);

--- a/components/projects/workspace/components/CreateNewElementModal.tsx
+++ b/components/projects/workspace/components/CreateNewElementModal.tsx
@@ -133,6 +133,8 @@ function defaultCategoryFolder(measureType: string): string {
     "Upper Floor Slab":                   "Superstructure / Slabs",
     "Lintel":                             "Architectural / Lintel",
     "Blockwork":                          "Architectural / External Walls (Blockwork/Brick)",
+    "External Blockwork":                 "Architectural / External Walls (Blockwork/Brick)",
+    "Internal Blockwork":                 "Architectural / Internal Walls (Partition)",
     "Roof":                               "Superstructure / Roof Structure",
     "Windows":                            "Architectural / Windows",
     "Doors":                              "Architectural / Doors",

--- a/components/projects/workspace/components/ElementDetailPanel.tsx
+++ b/components/projects/workspace/components/ElementDetailPanel.tsx
@@ -54,6 +54,9 @@ interface ElementDetailPanelProps {
   onTabChange?: (tab: "concrete" | "rebar") => void;
   /** Pointer handlers from the parent's drag logic — spread onto the header to make it a drag handle. */
   dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
+  /** Only meaningful when the category's config has blockworkSides === true. */
+  blockworkSide?: "external" | "internal";
+  onBlockworkSideChange?: (side: "external" | "internal") => void;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -79,14 +82,19 @@ export function ElementDetailPanel({
   onResetMeasurements,
   onTabChange,
   dragHandleProps,
+  blockworkSide = "external",
+  onBlockworkSideChange,
 }: ElementDetailPanelProps) {
   const cfg = ELEMENT_CONFIGS[measure] ?? ELEMENT_CONFIGS["Piles"];
+  const isBlockwork = cfg.blockworkSides === true;
   const rows =
     cfg.tool === "choice" && cfg.rowsByChoice
       ? cfg.rowsByChoice[measureChoice ?? "count"]
       : cfg.rows;
   const [activeTab, setActiveTab] = useState<"concrete" | "rebar">("concrete");
   const [savedFeedback, setSavedFeedback] = useState(false);
+  const blockworkLabel =
+    blockworkSide === "external" ? "External Blockwork" : "Internal Blockwork";
 
   // ── Concrete form ───────────────────────────────────────────────────────────
 
@@ -283,7 +291,9 @@ export function ElementDetailPanel({
         style={{ touchAction: "none", ...dragHandleProps?.style }}
         className="flex items-center justify-between px-4 py-3 border-b border-slate-200 shrink-0 cursor-grab active:cursor-grabbing"
       >
-        <span className="text-sm font-bold text-slate-800 uppercase tracking-wider">{measure}</span>
+        <span className="text-sm font-bold text-slate-800 uppercase tracking-wider">
+          {isBlockwork ? blockworkLabel : measure}
+        </span>
         <button
           onClick={onClose}
           onPointerDown={(e) => e.stopPropagation()}
@@ -294,29 +304,44 @@ export function ElementDetailPanel({
         </button>
       </div>
 
-      {/* Tabs */}
+      {/* Tabs — Blockwork gets External/Internal instead of Concrete/Rebar; each
+          switch is an independent element, not a view of the same data. */}
       <div className="flex shrink-0 border-b border-slate-200">
-        {(showRebarTab ? (["concrete", "rebar"] as const) : (["concrete"] as const)).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => { setActiveTab(tab); onTabChange?.(tab); }}
-            className={`flex-1 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
-              activeTab === tab
-                ? "text-amber-600 border-b-2 border-amber-500"
-                : "text-slate-400 hover:text-slate-600"
-            }`}
-          >
-            {tab}
-          </button>
-        ))}
+        {isBlockwork
+          ? (["external", "internal"] as const).map((side) => (
+              <button
+                key={side}
+                onClick={() => onBlockworkSideChange?.(side)}
+                className={`flex-1 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                  blockworkSide === side
+                    ? "text-amber-600 border-b-2 border-amber-500"
+                    : "text-slate-400 hover:text-slate-600"
+                }`}
+              >
+                {side === "external" ? "External" : "Internal"}
+              </button>
+            ))
+          : (showRebarTab ? (["concrete", "rebar"] as const) : (["concrete"] as const)).map((tab) => (
+              <button
+                key={tab}
+                onClick={() => { setActiveTab(tab); onTabChange?.(tab); }}
+                className={`flex-1 py-2.5 text-[11px] font-bold uppercase tracking-wider transition-colors ${
+                  activeTab === tab
+                    ? "text-amber-600 border-b-2 border-amber-500"
+                    : "text-slate-400 hover:text-slate-600"
+                }`}
+              >
+                {tab}
+              </button>
+            ))}
       </div>
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
-        {activeTab === "concrete" ? (
+        {activeTab === "concrete" || isBlockwork ? (
           <>
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-500">
-              {cfg.sectionHeader}
+              {isBlockwork ? "BLOCKWORK" : cfg.sectionHeader}
             </p>
 
             <div className="space-y-1">
@@ -324,7 +349,11 @@ export function ElementDetailPanel({
               <Input
                 value={fieldValues.tag ?? ""}
                 onChange={(e) => setField("tag", e.target.value)}
-                placeholder={cfg.tagPlaceholder}
+                placeholder={
+                  isBlockwork
+                    ? blockworkSide === "external" ? "e.g. EXT-01" : "e.g. INT-01"
+                    : cfg.tagPlaceholder
+                }
                 className="h-8 text-sm"
               />
             </div>

--- a/components/projects/workspace/components/constants.ts
+++ b/components/projects/workspace/components/constants.ts
@@ -83,6 +83,23 @@ const areaHeightOnly: ConcreteRowDef[] = [
   { fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] },
 ];
 
+export const WALL_TYPE_OPTIONS = ["100mm", "150mm", "225mm"];
+
+const blockworkRows: ConcreteRowDef[] = [
+  {
+    fields: [
+      { key: "height", label: "Height (m)", defaultValue: "0" },
+      {
+        key: "wallType",
+        label: "Wall Type",
+        type: "select",
+        defaultValue: WALL_TYPE_OPTIONS[0],
+        options: WALL_TYPE_OPTIONS,
+      },
+    ],
+  },
+];
+
 export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
   Piles: {
     tool: "count",
@@ -167,13 +184,14 @@ export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
   },
   "Blockwork on Foundation": {
     tool: "length",
-    sectionHeader: "BLOCKWORK (FROM MEASUREMENT)",
-    tagLabel: "Tag this run as:",
+    blockworkSides: true,
+    sectionHeader: "BLOCKWORK",
+    tagLabel: "Tag this Blockwork as:",
     tagPlaceholder: "e.g. BW-F1",
     measureLabel: "Length",
     measureUnit: "m",
     mockMeasureValue: "0",
-    rows: [{ fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] }],
+    rows: blockworkRows,
   },
   Columns: {
     tool: "choice",
@@ -235,13 +253,14 @@ export const ELEMENT_CONFIGS: Record<string, ElementConcreteConfig> = {
   },
   Blockwork: {
     tool: "length",
-    sectionHeader: "BLOCKWORK (FROM MEASUREMENT)",
-    tagLabel: "Tag this run as:",
+    blockworkSides: true,
+    sectionHeader: "BLOCKWORK",
+    tagLabel: "Tag this Blockwork as:",
     tagPlaceholder: "e.g. BW1",
     measureLabel: "Length",
     measureUnit: "m",
     mockMeasureValue: "0",
-    rows: [{ fields: [{ key: "height", label: "Height (m)", defaultValue: "0" }] }],
+    rows: blockworkRows,
   },
   Roof: {
     tool: "length",

--- a/components/projects/workspace/components/types.ts
+++ b/components/projects/workspace/components/types.ts
@@ -60,6 +60,9 @@ export interface ElementConcreteConfig {
   rows: ConcreteRowDef[];
   /** Only present when tool === "choice" — field rows per chosen tool. */
   rowsByChoice?: { count: ConcreteRowDef[]; area: ConcreteRowDef[] };
+  /** Blockwork-only: External/Internal act as independent measurement rounds
+   *  instead of the usual Concrete/Rebar tabs — no rebar involved at all. */
+  blockworkSides?: boolean;
 }
 
 // ─── Created element ──────────────────────────────────────────────────────────


### PR DESCRIPTION
…add Blockwork External/Internal tabs

Wheel zoom no longer fires when the cursor is over the floating Element panel. The panel now caps its height and scrolls instead of clipping overflowing content.

Live measurement totals shown in the panel were a counter that only ever incremented and drifted out of sync with the sidebar whenever undo/redo removed a mark. Replaced it with a value derived directly from the current canvas marks, excluding marks already claimed by a finished round, so it can never desync and naturally resets to zero on a new round without touching what's already drawn.

Blockwork and Blockwork on Foundation now skip the Bar Bending Schedule question and the Concrete/Rebar tabs entirely, replaced by independent External/Internal tabs (defaulting to External) with a new Wall Type field, each saved as its own separately categorized element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated External and Internal Blockwork measurement modes.
  * Added wall type options for blockwork measurements: 100mm, 150mm, and 225mm.
  * Blockwork measurements now save and restore the selected side correctly.
  * Added side-specific guidance and labels throughout the measurement panels.
* **Bug Fixes**
  * Improved session totals so completed measurement rounds no longer affect new rounds.
  * Previously saved marks are excluded from new live totals after restoring a project.
  * Blockwork categories now bypass unnecessary calibration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->