### PR TITLE
feat: frontend-only calibration, Live Measurements redesign, rotate t…

### DIFF
--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -7,6 +7,7 @@ import {
   ZoomIn,
   ZoomOut,
   Maximize2,
+  RotateCw,
   Expand,
   Ban,
   FolderOpen,
@@ -86,8 +87,12 @@ import { toast } from "sonner";
 import {
   loadSession,
   saveSession,
+  loadPageCalibration,
+  savePageCalibration,
+  clearPageCalibration,
   type WsConcreteMeasurement,
   type WsElementAssignment,
+  type VariantCalibration,
 } from "./workspaceSession";
 import type { SaveMeasurementPayload } from "./components/ElementDetailPanel";
 
@@ -328,6 +333,9 @@ function rebarToReinforcement(
   return result.length > 0 ? result : undefined;
 }
 
+// Stable reference so useMemo below doesn't create a new empty Set every render.
+const EMPTY_MARK_SET: ReadonlySet<string> = new Set();
+
 function DrawingHydrator({
   fileId,
   folderId,
@@ -406,8 +414,9 @@ export function ProjectWorkspaceView({
   const hydratedSessionIds = useRef<Set<string>>(new Set());
 
   const [createMeasurementSession] = useCreateMeasurementSessionMutation();
-  const [updateMeasurementCanvas, { isLoading: applyingScale }] =
-    useUpdateMeasurementCanvasMutation();
+  // Only called now when an element is actually assigned — calibration is
+  // otherwise applied locally, no backend round-trip while measuring.
+  const [updateMeasurementCanvas] = useUpdateMeasurementCanvasMutation();
   const [updateSessionStatus] = useUpdateMeasurementSessionStatusMutation();
   const [upsertMeasurementElement] = useUpsertMeasurementElementMutation();
   const [deleteMeasurementElement] = useDeleteMeasurementElementMutation();
@@ -440,6 +449,7 @@ export function ProjectWorkspaceView({
     setSelectedDrawingId(id);
     setSelectedPage(1);
     setScale(1.0);
+    setRotation(0);
   }, []);
 
   // ── Local UI state ──────────────────────────────────────────────────────────
@@ -455,6 +465,7 @@ export function ProjectWorkspaceView({
   );
   const [selectedPage, setSelectedPage] = useState(1);
   const [scale, setScale] = useState(1.0);
+  const [rotation, setRotation] = useState<0 | 90 | 180 | 270>(0);
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [openFolders, setOpenFolders] = useState<string[]>(() =>
     folders.map((f) => f.id),
@@ -597,6 +608,11 @@ export function ProjectWorkspaceView({
   const [calibPtCount, setCalibPtCount] = useState<0 | 1 | 2>(0);
   const [calibBasePxDist, setCalibBasePxDist] = useState<number | null>(null);
   const [calibPts, setCalibPts] = useState<[MPoint, MPoint] | null>(null);
+  // Snapshot taken at Apply Scale time — carried on every variant saved while
+  // this page's scale is active, since nothing pushes it to the backend
+  // until the variant's element is actually assigned.
+  const [appliedCalibration, setAppliedCalibration] =
+    useState<VariantCalibration | null>(null);
 
   // Live in-progress length from the canvas (A→cursor, null when not drawing)
   const [liveDrawingLength, setLiveDrawingLength] = useState<number | null>(
@@ -649,6 +665,28 @@ export function ProjectWorkspaceView({
     });
   }
 
+  // ── Click a Live Measurements row to bring its value + geometry back up ──────
+  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(null);
+
+  const selectedVariant = useMemo(() => {
+    if (!selectedVariantId) return null;
+    const allVariants = [
+      ...elements.flatMap((el) => el.variants),
+      ...concreteMeasurements,
+    ];
+    return allVariants.find((v) => v.id === selectedVariantId) ?? null;
+  }, [selectedVariantId, elements, concreteMeasurements]);
+
+  const highlightedMarkIds = useMemo(() => {
+    return selectedVariant
+      ? new Set(selectedVariant.canvas.measurementIds)
+      : EMPTY_MARK_SET;
+  }, [selectedVariant]);
+
+  function handleSelectVariant(variant: WsConcreteMeasurement) {
+    setSelectedVariantId((prev) => (prev === variant.id ? null : variant.id));
+  }
+
   // ── On mount: wipe stale backend-owned keys from localStorage AND live state ──
   // Scale, elements, and variants are now sourced from the backend session.
   // This runs once per projectId so stale data from before the migration — or from
@@ -680,6 +718,7 @@ export function ProjectWorkspaceView({
     setShowCalibrationBar(true);
     setScaleLocked(false);
     setGlobalScaleFactor(null);
+    setAppliedCalibration(null);
     setScaleInfo(null);
     setKnownDistance("");
     setActiveTool(null);
@@ -825,27 +864,78 @@ export function ProjectWorkspaceView({
       }
     }
 
-    if (measurements.length > 0 || isGenuinelyCalibrated) {
-      measurementHook.resetWithData({
-        scaleFactor: isGenuinelyCalibrated ? backendScale : null,
-        calibPts: null,
-        measurements,
-      });
-      // These marks belong to already-saved elements from a prior round —
-      // exclude them from the next fresh round's live totals.
-      if (measurements.length > 0) {
-        setClaimedMarkIds((prev) => {
-          const next = new Set(prev);
-          for (const m of measurements) next.add(m.id);
-          return next;
+    // Marks now live in localStorage (useCanvasMeasurements already loaded this
+    // page's marks from its own storage before this effect ever runs) — drawing
+    // no longer pushes to the backend, so `measurements` here is only whatever
+    // was already finalized into a real element. Never blindly resetWithData:
+    // that would wipe out local-only, not-yet-finalized marks. Merge instead —
+    // add only backend marks the local state doesn't already have.
+    if (measurements.length > 0) {
+      const existingIds = new Set(
+        measurementHook.state.measurements.map((m) => m.id),
+      );
+      const newFromBackend = measurements.filter((m) => !existingIds.has(m.id));
+      if (newFromBackend.length > 0) {
+        measurementHook.resetWithData({
+          scaleFactor: isGenuinelyCalibrated ? backendScale : null,
+          calibPts: null,
+          measurements: [...measurementHook.state.measurements, ...newFromBackend],
         });
       }
+      // These marks belong to already-saved elements from a prior round —
+      // exclude them from the next fresh round's live totals.
+      setClaimedMarkIds((prev) => {
+        const next = new Set(prev);
+        for (const m of measurements) next.add(m.id);
+        return next;
+      });
     }
   }, [
     activeSessionData,
     activeSessionId,
     distanceUnit,
     measurementHook.resetWithData,
+  ]);
+
+  // ── Restore this page's calibration from localStorage ────────────────────────
+  // Calibration is frontend-only now (see handleApplyScale) — the backend never
+  // learns about it until an element is assigned, so it can't be the thing that
+  // restores scale on reload for a page that hasn't had anything assigned yet.
+  // measurementHook.state.scaleFactor is already loaded from ITS OWN page-scoped
+  // storage by the time this runs; pair it with the calibration metadata
+  // (knownDistance/unit) saved alongside it to fully restore the UI state.
+  useEffect(() => {
+    if (globalScaleFactor !== null) return; // already restored, e.g. via backend hydration
+    const uploadedFileId = selectedDrawing?.uploadedFileId;
+    if (!uploadedFileId) return;
+    const localScaleFactor = measurementHook.state.scaleFactor;
+    if (!localScaleFactor) return;
+    const saved = loadPageCalibration(uploadedFileId, selectedPage);
+    if (!saved) return;
+
+    setGlobalScaleFactor(localScaleFactor);
+    setKnownDistance(saved.knownDistance);
+    setDistanceUnit(saved.distanceUnit);
+    setScaleInfo(saved.scaleInfo);
+    setScaleLocked(saved.scaleLocked);
+    setScaleFlowActive(true);
+    setShowElementPanel(true);
+    setAppliedCalibration({
+      knownDistance: parseFloat(saved.knownDistance) || 0,
+      pixelDistance: measurementHook.state.calibPts
+        ? Math.hypot(
+            measurementHook.state.calibPts[1].x - measurementHook.state.calibPts[0].x,
+            measurementHook.state.calibPts[1].y - measurementHook.state.calibPts[0].y,
+          )
+        : 0,
+      unit: toBackendDistanceUnit(saved.distanceUnit),
+    });
+  }, [
+    selectedDrawing?.uploadedFileId,
+    selectedPage,
+    measurementHook.state.scaleFactor,
+    measurementHook.state.calibPts,
+    globalScaleFactor,
   ]);
 
   // ── Global element loader: merge assigned elements from ALL project sessions ──
@@ -985,6 +1075,7 @@ export function ProjectWorkspaceView({
         unit: distanceUnit,
         measurementIds,
       },
+      calibration: appliedCalibration,
       sessionId: activeSessionId,
       drawingId: selectedDrawing?.uploadedFileId ?? null,
       pageNumber: selectedPage,
@@ -1000,8 +1091,6 @@ export function ProjectWorkspaceView({
       saveSession(projectId, { concreteMeasurements: next });
       return next;
     });
-
-    upsertPendingVariant(variant, activeSessionId);
 
     setAutoSaveStatus("saving");
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
@@ -1338,7 +1427,11 @@ export function ProjectWorkspaceView({
   // Scale only takes effect locally once the backend confirms it — this is what
   // actually gates drawing (via isCalibrating in MeasurementCanvas), so a failed
   // save must never leave the app acting as if scale was applied.
-  async function handleApplyScale() {
+  // Applied entirely on the frontend — no backend call here. The calibration
+  // snapshot is instead carried on every variant saved while it's active, and
+  // only reaches the backend when that variant's element is actually assigned
+  // (see persistVariantsToBackend).
+  function handleApplyScale() {
     if (!knownDistance) {
       toast.warning("Enter a known distance first");
       return;
@@ -1354,34 +1447,26 @@ export function ProjectWorkspaceView({
       toast.warning("Enter a valid distance greater than 0");
       return;
     }
-    if (!activeSessionId) {
-      toast.error("No active session — reopen the page and try again.");
-      return;
-    }
 
     // scaleFactor = base pixels per real unit
     const sf = calibBasePxDist / realDist;
 
-    try {
-      await updateMeasurementCanvas({
-        sessionId: activeSessionId,
-        body: {
-          calibration: {
-            knownDistance: realDist,
-            pixelDistance: calibBasePxDist,
-            unit: toBackendDistanceUnit(distanceUnit),
-          },
-        },
-      }).unwrap();
-    } catch {
-      toast.error(
-        "Could not save the scale — check your connection and try again.",
-      );
-      return;
-    }
+    // TEMP diagnostic — remove once the pixel-to-real-unit bug is found.
+    console.log("[CALIBRATION]", {
+      pdfZoom: scale,
+      calibBasePxDist,
+      knownDistanceEntered: realDist,
+      unit: distanceUnit,
+      scaleFactor_pxPerUnit: sf,
+    });
 
     setGlobalScaleFactor(sf);
     measurementHook.setCalibration(calibPts, sf);
+    setAppliedCalibration({
+      knownDistance: realDist,
+      pixelDistance: calibBasePxDist,
+      unit: toBackendDistanceUnit(distanceUnit),
+    });
 
     const approxRatio = Math.round(calibBasePxDist / realDist);
     const newScaleInfo = `Scale: 1:${approxRatio} | ${sf.toFixed(1)} px/${distanceUnit}`;
@@ -1401,6 +1486,14 @@ export function ProjectWorkspaceView({
       scaleLocked: false,
       scaleFactor: sf,
     });
+    if (selectedDrawing?.uploadedFileId) {
+      savePageCalibration(selectedDrawing.uploadedFileId, selectedPage, {
+        knownDistance,
+        distanceUnit,
+        scaleInfo: newScaleInfo,
+        scaleLocked: false,
+      });
+    }
   }
 
   function handleShowCalibrationBar() {
@@ -1409,6 +1502,23 @@ export function ProjectWorkspaceView({
       calibrationBarHideTimerRef.current = null;
     }
     setShowCalibrationBar(true);
+  }
+
+  // Keeps this page's calibration restorable after a reload — calibration is
+  // frontend/localStorage-only now, so Lock Scale toggling needs to update the
+  // page-scoped record the same way handleApplyScale does when it's first set.
+  function handleToggleScaleLock(locked: boolean) {
+    setScaleLocked(locked);
+    saveSession(projectId, { scaleLocked: locked });
+    const uploadedFileId = selectedDrawing?.uploadedFileId;
+    if (uploadedFileId && scaleInfo) {
+      savePageCalibration(uploadedFileId, selectedPage, {
+        knownDistance,
+        distanceUnit,
+        scaleInfo,
+        scaleLocked: locked,
+      });
+    }
   }
 
   function handleResetScale() {
@@ -1431,6 +1541,7 @@ export function ProjectWorkspaceView({
     setCalibPtCount(0);
     setCalibBasePxDist(null);
     setCalibPts(null);
+    setAppliedCalibration(null);
     setColumnMeasureChoice(null);
     setElementPanelTab("concrete");
     setRebarDrawnLength(null);
@@ -1441,6 +1552,9 @@ export function ProjectWorkspaceView({
       scaleFlowActive: false,
       scaleFactor: null,
     });
+    if (selectedDrawing?.uploadedFileId) {
+      clearPageCalibration(selectedDrawing.uploadedFileId, selectedPage);
+    }
   }
 
   function handleSaveMeasurement(payload: SaveMeasurementPayload) {
@@ -1457,6 +1571,7 @@ export function ProjectWorkspaceView({
       concreteFields: payload.concreteFields,
       rebar: payload.rebar,
       canvas: { ...payload.canvas, measurementIds },
+      calibration: appliedCalibration,
       sessionId: activeSessionId,
       drawingId: selectedDrawing?.uploadedFileId ?? null,
       pageNumber: selectedPage,
@@ -1476,10 +1591,6 @@ export function ProjectWorkspaceView({
     // Cycle to a fresh ID so the next measurement round gets its own slot.
     currentVariantId.current = crypto.randomUUID();
     lastFormPayload.current = null;
-
-    if (activeSessionId) {
-      upsertPendingVariant(variant, activeSessionId);
-    }
   }
 
   // ── Assign element flow ───────────────────────────────────────────────────────
@@ -1676,6 +1787,7 @@ export function ProjectWorkspaceView({
     setSelectedDrawingId(drawing.id);
     setSelectedPage(el.pageNumber || 1);
     setScale(1.0);
+    setRotation(0);
     setDrawingsOpen(false);
   }
 
@@ -1751,6 +1863,16 @@ export function ProjectWorkspaceView({
     measurementUnit: string,
   ) {
     const allMeasurements = measurementHook.state.measurements;
+
+    // Calibration was applied locally only (no backend call at Apply Scale time
+    // anymore) — send it now, once, as part of actually assigning the element.
+    const calibratedVariant = variants.find((v) => v.calibration);
+    if (calibratedVariant?.calibration) {
+      updateMeasurementCanvas({
+        sessionId,
+        body: { calibration: calibratedVariant.calibration },
+      });
+    }
 
     for (const variant of variants) {
       const variantMarks = allMeasurements.filter((m) =>
@@ -1834,67 +1956,6 @@ export function ProjectWorkspaceView({
     }
   }
 
-  // ── Upsert a single variant to the backend immediately on "Apply & Continue" ──
-  // Uses variant.id as clientId so it is idempotent and cleanly overwritten
-  // (count) or deleted (length/area) when the element is later assigned.
-  function upsertPendingVariant(
-    variant: WsConcreteMeasurement,
-    sessionId: string,
-  ) {
-    const allMeasurements = measurementHook.state.measurements;
-    const variantMarks = allMeasurements.filter((m) =>
-      variant.canvas.measurementIds.includes(m.id),
-    );
-    const backendType = toBackendElementType(variant.measureType);
-    const color = variantMarks[0]?.color ?? "#f59e0b";
-    const _snapshot = JSON.stringify({
-      ...variant,
-      canvas: { ...variant.canvas, measurementIds: [] },
-    });
-    const pendingAttrs: Record<string, unknown> = {
-      pending: true,
-      measureType: variant.measureType,
-      _snapshot,
-      reinforcement: rebarToReinforcement(variant.rebar),
-    };
-
-    if (variant.canvas.tool === "count") {
-      const points: [number, number][] = variantMarks
-        .filter((m): m is CountMark => m.type === "count")
-        .map((m) => [m.point.x, m.point.y]);
-      if (points.length === 0) return;
-      upsertMeasurementElement({
-        sessionId,
-        body: {
-          clientId: variant.id,
-          tool: "count",
-          label: variant.tag || variant.measureType,
-          mapsToElementType: backendType,
-          geometry: { type: "multipoint", points, page: variant.pageNumber },
-          style: { color, strokeWidth: 2 },
-          attributes: pendingAttrs,
-        },
-      });
-    } else {
-      // For length/area pending: send first mark's geometry under variant.id so
-      // persistVariantsToBackend can delete it cleanly on assignment.
-      const firstMark = variantMarks[0];
-      if (!firstMark) return;
-      const baseBody = measurementToBackendBody(firstMark);
-      upsertMeasurementElement({
-        sessionId,
-        body: {
-          ...baseBody,
-          clientId: variant.id,
-          label: variant.tag || variant.measureType,
-          mapsToElementType: backendType,
-          geometry: { ...baseBody.geometry!, page: variant.pageNumber },
-          style: { color, strokeWidth: 2 },
-          attributes: pendingAttrs,
-        },
-      });
-    }
-  }
 
   // ── Session conflict resolution (409 on session create) ──────────────────────
 
@@ -1912,6 +1973,7 @@ export function ProjectWorkspaceView({
         setSelectedDrawingId(drawing.id);
         setSelectedPage(pageNumber ?? 1);
         setScale(1.0);
+        setRotation(0);
       }
     }
     setSessionConflict(null);
@@ -1980,15 +2042,35 @@ export function ProjectWorkspaceView({
   const zoomIn = () => setScale((s) => Math.min(+(s + 0.25).toFixed(2), 3));
   const zoomOut = () => setScale((s) => Math.max(+(s - 0.25).toFixed(2), 0.25));
   const resetZoom = () => setScale(1.0);
+  const rotateDrawing = () =>
+    setRotation((r) => ((r + 90) % 360) as 0 | 90 | 180 | 270);
 
-  // Mouse wheel and trackpad pinch (browsers report pinch as wheel + ctrlKey) both zoom.
-  function handleCanvasWheel(e: React.WheelEvent<HTMLDivElement>) {
-    e.preventDefault();
-    setScale((s) => {
-      const next = e.deltaY > 0 ? s - 0.1 : s + 0.1;
-      return Math.min(Math.max(+next.toFixed(2), 0.25), 3);
-    });
-  }
+  // Mouse wheel and trackpad pinch (browsers report pinch as wheel + ctrlKey) both
+  // zoom, and only while the cursor is over the drawing itself. Attached as a real
+  // native listener (not React's onWheel) with { passive: false } — React's
+  // synthetic wheel handler isn't guaranteed non-passive in every browser, so
+  // preventDefault() inside it can silently no-op and let the browser's own
+  // native pinch/ctrl+wheel page-zoom fire at the same time. A real non-passive
+  // listener is the only way to reliably suppress that.
+  useEffect(() => {
+    const el = canvasAreaRef.current;
+    if (!el) return;
+    function onWheel(e: WheelEvent) {
+      // Scrolling inside the floating Element panel should scroll that panel,
+      // not zoom the drawing underneath it — a native listener on an ancestor
+      // fires during real DOM bubbling, before React's synthetic event system
+      // even runs, so a descendant's React-level stopPropagation can't stop
+      // this one; check the actual target instead.
+      if (elementPanelRef.current?.contains(e.target as Node)) return;
+      e.preventDefault();
+      setScale((s) => {
+        const next = e.deltaY > 0 ? s - 0.1 : s + 0.1;
+        return Math.min(Math.max(+next.toFixed(2), 0.25), 3);
+      });
+    }
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
 
   function handleSidebarToggle() {
     setSidebarCollapsed((prev) => {
@@ -2003,11 +2085,13 @@ export function ProjectWorkspaceView({
     setSelectedDrawingId(fileId);
     setSelectedPage(1);
     setScale(1.0);
+    setRotation(0);
   }
   function handleSelectPage(fileId: string, pageNum: number) {
     if (selectedDrawingId !== fileId) {
       setSelectedDrawingId(fileId);
       setScale(1.0);
+      setRotation(0);
     }
     setSelectedPage(pageNum);
   }
@@ -2016,12 +2100,15 @@ export function ProjectWorkspaceView({
     (id: string, numPages: number) => {
       const drawing = drawings.find((d) => d.id === id);
       if (!drawing || drawing.pageCount === numPages) return;
+      const baseName = drawing.name.replace(/\.[^.]+$/, "");
+      const truncatedName =
+        baseName.length > 10 ? `${baseName.slice(0, 10)}...` : baseName;
       dispatch(
         setDrawingPages({
           id,
           pages: Array.from({ length: numPages }, (_, i) => ({
             number: i + 1,
-            label: `Page ${i + 1}`,
+            label: `${truncatedName}${i + 1}`,
           })),
         }),
       );
@@ -2135,6 +2222,7 @@ export function ProjectWorkspaceView({
       setSelectedDrawingId(firstNewId);
       setSelectedPage(1);
       setScale(1.0);
+      setRotation(0);
     }
   }
 
@@ -2712,13 +2800,17 @@ export function ProjectWorkspaceView({
           <div className="flex-1 min-h-0 flex overflow-hidden">
             <div
               ref={canvasAreaRef}
-              onWheel={handleCanvasWheel}
               className="flex-1 min-w-0 relative overflow-hidden bg-[#e8edf2]"
             >
               <DrawingCanvas
                 drawing={selectedDrawing}
                 page={selectedPage}
                 scale={scale}
+                rotation={rotation}
+                panEnabled={
+                  !(scaleFlowActive && !scaleLocked) &&
+                  (!activeTool || activeTool === "text")
+                }
                 onPageCountResolved={handlePageCountResolved}
                 measurementOverlay={
                   <MeasurementCanvas
@@ -2729,6 +2821,7 @@ export function ProjectWorkspaceView({
                     distanceUnit={distanceUnit}
                     activeColor={activeColor}
                     measurements={measurementHook.state.measurements}
+                    highlightedIds={highlightedMarkIds}
                     nextCountIndex={nextCountIndex}
                     pageKey={`${selectedDrawingId ?? "none"}-${selectedPage}`}
                     onCalibrationUpdate={handleCalibrationUpdate}
@@ -2765,6 +2858,14 @@ export function ProjectWorkspaceView({
                 >
                   <Maximize2 className="w-3.5 h-3.5" />
                 </button>
+                <div className="h-px bg-slate-200 mx-0.5" />
+                <button
+                  onClick={rotateDrawing}
+                  className="w-7 h-7 flex items-center justify-center rounded hover:bg-slate-100 text-slate-500"
+                  title="Rotate drawing 90°"
+                >
+                  <RotateCw className="w-3.5 h-3.5" />
+                </button>
               </div>
 
               {/* Page indicator */}
@@ -2784,7 +2885,6 @@ export function ProjectWorkspaceView({
               {showElementPanel && (
                 <div
                   ref={elementPanelRef}
-                  onWheel={(e) => e.stopPropagation()}
                   className={`absolute z-20 ${elementPanelPos ? "" : "right-6 top-4"}`}
                   style={
                     elementPanelPos
@@ -2822,6 +2922,7 @@ export function ProjectWorkspaceView({
                         liveLength={effectiveConcreteLength}
                         liveArea={sessionTotals.area}
                         liveRebarLength={rebarDrawnLength}
+                        selectedVariant={selectedVariant}
                         distanceUnit={distanceUnit}
                         hasMeasurements={
                           sessionTotals.count > 0 ||
@@ -2925,7 +3026,6 @@ export function ProjectWorkspaceView({
                           onChange={(e) => setKnownDistance(e.target.value)}
                           className="h-9 flex-1 text-sm"
                           placeholder="0"
-                          disabled={applyingScale}
                         />
                         <Select
                           value={distanceUnit}
@@ -2944,10 +3044,9 @@ export function ProjectWorkspaceView({
                         </Select>
                         <Button
                           onClick={handleApplyScale}
-                          disabled={applyingScale}
-                          className="h-9 bg-amber-500 hover:bg-amber-600 text-white text-[12px] font-semibold px-5 shrink-0 disabled:opacity-60"
+                          className="h-9 bg-amber-500 hover:bg-amber-600 text-white text-[12px] font-semibold px-5 shrink-0"
                         >
-                          {applyingScale ? "Saving…" : "Apply Scale"}
+                          Apply Scale
                         </Button>
                       </div>
                     </div>
@@ -2976,8 +3075,7 @@ export function ProjectWorkspaceView({
                       </span>
                       <button
                         onClick={() => {
-                          setScaleLocked(true);
-                          saveSession(projectId, { scaleLocked: true });
+                          handleToggleScaleLock(true);
                           if (calibrationBarHideTimerRef.current)
                             clearTimeout(calibrationBarHideTimerRef.current);
                           calibrationBarHideTimerRef.current = setTimeout(
@@ -3017,8 +3115,7 @@ export function ProjectWorkspaceView({
                         </span>
                         <button
                           onClick={() => {
-                            setScaleLocked(false);
-                            saveSession(projectId, { scaleLocked: false });
+                            handleToggleScaleLock(false);
                             handleShowCalibrationBar();
                           }}
                           className="relative w-9 h-5 rounded-full bg-green-500 transition-colors"
@@ -3078,8 +3175,9 @@ export function ProjectWorkspaceView({
             <LiveMeasurementsPanel
               elements={elements}
               pendingVariants={concreteMeasurements}
-              scaleWhat={effectiveMeasureType}
               distanceUnit={distanceUnit}
+              selectedVariantId={selectedVariantId}
+              onSelectVariant={handleSelectVariant}
             />
           )}
         </div>

--- a/components/projects/workspace/components/DrawingCanvas.tsx
+++ b/components/projects/workspace/components/DrawingCanvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
@@ -38,12 +38,19 @@ export function DrawingCanvas({
   drawing,
   page,
   scale,
+  rotation = 0,
+  panEnabled = false,
   onPageCountResolved,
   measurementOverlay,
 }: {
   drawing: DrawingFile | null;
   page: number;
   scale: number;
+  /** Visual rotation in degrees — applied to the page and its measurement
+   *  overlay together, so drawn marks stay aligned with the rotated page. */
+  rotation?: 0 | 90 | 180 | 270;
+  /** Click-and-drag panning — only offered when no measurement tool is actively drawing. */
+  panEnabled?: boolean;
   onPageCountResolved: (id: string, numPages: number) => void;
   /** Konva measurement canvas — rendered only over PDF pages */
   measurementOverlay?: React.ReactNode;
@@ -52,6 +59,55 @@ export function DrawingCanvas({
     () => (drawing?.extension ? VIEWER_MAP[drawing.extension.toLowerCase()] ?? "unsupported" : null),
     [drawing?.extension]
   );
+
+  // ── Click-and-drag panning (PDF path scrolls its own overflow-auto container) ──
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const panState = useRef<{
+    startX: number;
+    startY: number;
+    startScrollLeft: number;
+    startScrollTop: number;
+    moved: boolean;
+  } | null>(null);
+
+  function handlePanPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+    // Middle-mouse-button drag pans regardless of the active tool — browsers
+    // never fire a "click" event for the middle button, so this can never be
+    // mistaken for a tool placement (count/length/area clicks are left-button
+    // "click" events only). Plain left-button drag only pans when no tool is
+    // actively drawing (panEnabled), so it never steals a tool's clicks.
+    const isMiddleButton = e.button === 1;
+    if (!isMiddleButton && !panEnabled) return;
+    if (isMiddleButton) e.preventDefault();
+    const el = scrollRef.current;
+    if (!el) return;
+    panState.current = {
+      startX: e.clientX,
+      startY: e.clientY,
+      startScrollLeft: el.scrollLeft,
+      startScrollTop: el.scrollTop,
+      moved: false,
+    };
+    setIsPanning(true);
+    el.setPointerCapture(e.pointerId);
+  }
+
+  function handlePanPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    const ps = panState.current;
+    const el = scrollRef.current;
+    if (!ps || !el) return;
+    const dx = e.clientX - ps.startX;
+    const dy = e.clientY - ps.startY;
+    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) ps.moved = true;
+    el.scrollLeft = ps.startScrollLeft - dx;
+    el.scrollTop = ps.startScrollTop - dy;
+  }
+
+  function handlePanPointerUp() {
+    panState.current = null;
+    setIsPanning(false);
+  }
 
   if (!drawing) {
     return (
@@ -65,10 +121,29 @@ export function DrawingCanvas({
   // ── PDF ──────────────────────────────────────────────────────────────────────
   if (viewerType === "pdf" && drawing.previewUrl) {
     return (
-      <div className="flex items-start justify-center h-full overflow-auto p-6">
+      <div
+        ref={scrollRef}
+        onPointerDown={handlePanPointerDown}
+        onPointerMove={handlePanPointerMove}
+        onPointerUp={handlePanPointerUp}
+        onPointerCancel={handlePanPointerUp}
+        style={panEnabled ? { touchAction: "none" } : undefined}
+        className={`flex items-start justify-center h-full overflow-auto p-6 ${
+          panEnabled ? (isPanning ? "cursor-grabbing" : "cursor-grab") : ""
+        }`}
+      >
         {/* Wrapper is inline so it sizes to the rendered page, not the scroll container.
-            The measurement overlay is absolute inset-0 over exactly this element. */}
-        <div className="relative inline-block">
+            The measurement overlay is absolute inset-0 over exactly this element —
+            rotating this wrapper (not the scroll container) keeps drawn marks
+            aligned with the page, since both rotate together as one unit. */}
+        <div
+          className="relative inline-block"
+          style={
+            rotation
+              ? { transform: `rotate(${rotation}deg)`, transformOrigin: "center center" }
+              : undefined
+          }
+        >
           <Document
             file={drawing.previewUrl}
             onLoadSuccess={({ numPages }) => onPageCountResolved(drawing.id, numPages)}
@@ -100,7 +175,7 @@ export function DrawingCanvas({
             src={src}
             alt={drawing.name}
             style={{
-              transform: `scale(${scale})`,
+              transform: `scale(${scale}) rotate(${rotation}deg)`,
               transformOrigin: "center",
               transition: "transform 0.15s ease",
             }}

--- a/components/projects/workspace/components/ElementDetailPanel.tsx
+++ b/components/projects/workspace/components/ElementDetailPanel.tsx
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ELEMENT_CONFIGS, BAR_SIZE_OPTIONS, PALETTE, PALETTE_LABELS } from "./constants";
 import type { RebarBar } from "./types";
-import type { VariantRebar } from "../workspaceSession";
+import type { VariantRebar, WsConcreteMeasurement } from "../workspaceSession";
 
 // ─── Prop types ───────────────────────────────────────────────────────────────
 
@@ -57,6 +57,9 @@ interface ElementDetailPanelProps {
   /** Only meaningful when the category's config has blockworkSides === true. */
   blockworkSide?: "external" | "internal";
   onBlockworkSideChange?: (side: "external" | "internal") => void;
+  /** Set when a Live Measurements row is clicked — overrides the Measured
+   *  display with that saved variant's own value instead of the live round. */
+  selectedVariant?: WsConcreteMeasurement | null;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -84,7 +87,12 @@ export function ElementDetailPanel({
   dragHandleProps,
   blockworkSide = "external",
   onBlockworkSideChange,
+  selectedVariant = null,
 }: ElementDetailPanelProps) {
+  const displayTool = selectedVariant ? selectedVariant.canvas.tool : activeMeasureTool;
+  const displayCount = selectedVariant ? selectedVariant.canvas.count : liveCount;
+  const displayLength = selectedVariant ? selectedVariant.canvas.length : liveLength;
+  const displayArea = selectedVariant ? selectedVariant.canvas.area : liveArea;
   const cfg = ELEMENT_CONFIGS[measure] ?? ELEMENT_CONFIGS["Piles"];
   const isBlockwork = cfg.blockworkSides === true;
   const rows =
@@ -359,18 +367,25 @@ export function ElementDetailPanel({
             </div>
 
             <div className="space-y-1">
-              <label className="text-[11px] text-slate-500">{cfg.measureLabel}</label>
-              {activeMeasureTool ? (
+              <div className="flex items-center justify-between gap-2">
+                <label className="text-[11px] text-slate-500">{cfg.measureLabel}</label>
+                {selectedVariant && (
+                  <span className="text-[10px] font-semibold text-blue-600 bg-blue-50 border border-blue-200 rounded-full px-2 py-0.5 whitespace-nowrap">
+                    Viewing: {selectedVariant.tag || selectedVariant.measureType}
+                  </span>
+                )}
+              </div>
+              {displayTool ? (
                 <div className="flex items-baseline gap-1.5">
-                  <p className="text-2xl font-bold text-amber-600 tabular-nums">
-                    {activeMeasureTool === "count" && liveCount}
-                    {activeMeasureTool === "length" && liveLength.toFixed(2)}
-                    {activeMeasureTool === "area" && liveArea.toFixed(2)}
+                  <p className={`text-2xl font-bold tabular-nums ${selectedVariant ? "text-blue-600" : "text-amber-600"}`}>
+                    {displayTool === "count" && displayCount}
+                    {displayTool === "length" && displayLength.toFixed(2)}
+                    {displayTool === "area" && displayArea.toFixed(2)}
                   </p>
                   <span className="text-sm text-slate-500">
-                    {activeMeasureTool === "count" && "placed"}
-                    {activeMeasureTool === "length" && distanceUnit}
-                    {activeMeasureTool === "area" &&
+                    {displayTool === "count" && "placed"}
+                    {displayTool === "length" && distanceUnit}
+                    {displayTool === "area" &&
                       (distanceUnit === "Meters" ? "m²" : `${distanceUnit}²`)}
                   </span>
                 </div>

--- a/components/projects/workspace/components/LiveMeasurementsPanel.tsx
+++ b/components/projects/workspace/components/LiveMeasurementsPanel.tsx
@@ -9,92 +9,81 @@ import type { WsConcreteMeasurement } from "../workspaceSession";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function variantLabel(el: CreatedElement): string {
-  const count = el.variants.length;
-  if (count === 0) return "—";
-  return `${count} ${el.name}`;
+function unitLabel(distanceUnit: string, squared: boolean): string {
+  const base = distanceUnit === "Meters" ? "m" : distanceUnit;
+  return squared ? `${base}²` : base;
 }
 
-function measuredTotal(variants: WsConcreteMeasurement[], distanceUnit: string): string {
-  if (variants.length === 0) return "0.00";
-  const tool = variants[0].canvas.tool;
-  if (tool === "count") {
-    const total = variants.reduce((s, v) => s + v.canvas.count, 0);
-    return `${total}`;
-  }
-  if (tool === "length") {
-    const total = variants.reduce((s, v) => s + v.canvas.length, 0);
-    return `${total.toFixed(2)} ${distanceUnit === "Meters" ? "m" : distanceUnit}`;
-  }
-  const total = variants.reduce((s, v) => s + v.canvas.area, 0);
-  return `${total.toFixed(2)} ${distanceUnit === "Meters" ? "m²" : `${distanceUnit}²`}`;
+function volumeDisplay(variant: WsConcreteMeasurement): string {
+  const vol = parseFloat(computeVolume(variant.measureType, variant.concreteFields, variant.canvas));
+  return !isNaN(vol) && vol > 0 ? `${vol.toFixed(2)} m³` : "—";
 }
 
-function volumeTotal(variants: WsConcreteMeasurement[]): string {
-  if (variants.length === 0) return "0.00";
-  const total = variants.reduce((s, v) => {
-    const vol = parseFloat(computeVolume(v.measureType, v.concreteFields, v.canvas));
-    return s + (isNaN(vol) ? 0 : vol);
-  }, 0);
-  return total > 0 ? `${total.toFixed(2)} m³` : "0.00";
-}
-
-function rebarSummary(variants: WsConcreteMeasurement[]): string {
+function rebarDisplay(variant: WsConcreteMeasurement): string {
+  if (!variant.rebar) return "—";
   let totalBars = 0;
-  for (const v of variants) {
-    if (!v.rebar) continue;
-    for (const bar of [...v.rebar.mainBars, ...v.rebar.additionBars]) {
-      const n = parseInt(bar.count, 10);
-      if (!isNaN(n)) totalBars += n;
-    }
+  for (const bar of [...variant.rebar.mainBars, ...variant.rebar.additionBars]) {
+    const n = parseInt(bar.count, 10);
+    if (!isNaN(n)) totalBars += n;
   }
   return totalBars > 0 ? `${totalBars} bars` : "—";
 }
 
 // ─── Row ──────────────────────────────────────────────────────────────────────
 
-function TableRow({
-  element,
-  label,
-  measured,
-  volume,
-  rebar,
-  inProgress = false,
+function VariantRow({
+  variant,
+  distanceUnit,
+  inProgress,
+  selected,
+  onSelect,
 }: {
-  element: string;
-  label: string;
-  measured: string;
-  volume: string;
-  rebar: string;
-  inProgress?: boolean;
+  variant: WsConcreteMeasurement;
+  distanceUnit: string;
+  inProgress: boolean;
+  selected: boolean;
+  onSelect: () => void;
 }) {
+  const tool = variant.canvas.tool;
+  const countDisplay = tool === "count" ? `${variant.canvas.count}` : "—";
+  const lengthDisplay =
+    tool === "length" ? `${variant.canvas.length.toFixed(2)} ${unitLabel(distanceUnit, false)}` : "—";
+  const areaDisplay =
+    tool === "area" ? `${variant.canvas.area.toFixed(2)} ${unitLabel(distanceUnit, true)}` : "—";
+
   return (
     <tr
-      className={`border-b border-slate-100 last:border-0 ${
-        inProgress ? "bg-blue-50/60" : "hover:bg-slate-50/60"
+      onClick={onSelect}
+      className={`border-b border-slate-100 last:border-0 cursor-pointer transition-colors ${
+        selected
+          ? "bg-amber-50"
+          : inProgress
+            ? "bg-blue-50/60 hover:bg-blue-50"
+            : "hover:bg-slate-50/60"
       }`}
     >
       <td className="px-3 py-2.5">
-        <div className={`text-[12px] font-semibold ${inProgress ? "text-blue-600" : "text-slate-700"}`}>
-          {element}
+        <div className={`text-[12px] font-semibold ${selected ? "text-amber-700" : inProgress ? "text-blue-600" : "text-slate-700"}`}>
+          {variant.tag || variant.measureType}
         </div>
-        {inProgress && (
-          <div className="text-[10px] font-bold text-blue-400 uppercase tracking-wide">
-            In Progress
-          </div>
-        )}
+        <div className={`text-[10px] font-bold uppercase tracking-wide ${inProgress ? "text-blue-400" : "text-slate-400"}`}>
+          {inProgress ? "In Progress" : variant.measureType}
+        </div>
       </td>
-      <td className={`px-3 py-2.5 text-[12px] ${inProgress ? "text-blue-500" : "text-slate-600"}`}>
-        {label}
+      <td className={`px-3 py-2.5 text-[12px] ${selected ? "text-amber-700" : inProgress ? "text-blue-500" : "text-slate-600"}`}>
+        {countDisplay}
       </td>
-      <td className={`px-3 py-2.5 text-[12px] ${inProgress ? "text-blue-500" : "text-slate-600"}`}>
-        {measured}
+      <td className={`px-3 py-2.5 text-[12px] ${selected ? "text-amber-700" : inProgress ? "text-blue-500" : "text-slate-600"}`}>
+        {lengthDisplay}
       </td>
-      <td className={`px-3 py-2.5 text-[12px] ${inProgress ? "text-blue-500" : "text-slate-600"}`}>
-        {volume}
+      <td className={`px-3 py-2.5 text-[12px] ${selected ? "text-amber-700" : inProgress ? "text-blue-500" : "text-slate-600"}`}>
+        {areaDisplay}
       </td>
-      <td className={`px-3 py-2.5 text-[12px] ${inProgress ? "text-blue-500" : "text-slate-600"}`}>
-        {rebar}
+      <td className={`px-3 py-2.5 text-[12px] ${selected ? "text-amber-700" : inProgress ? "text-blue-500" : "text-slate-600"}`}>
+        {volumeDisplay(variant)}
+      </td>
+      <td className={`px-3 py-2.5 text-[12px] ${selected ? "text-amber-700" : inProgress ? "text-blue-500" : "text-slate-600"}`}>
+        {rebarDisplay(variant)}
       </td>
     </tr>
   );
@@ -103,21 +92,25 @@ function TableRow({
 function MeasurementTable({
   elements,
   pendingVariants,
-  scaleWhat,
   distanceUnit,
+  selectedVariantId,
+  onSelectVariant,
 }: {
   elements: CreatedElement[];
   pendingVariants: WsConcreteMeasurement[];
-  scaleWhat: string;
   distanceUnit: string;
+  selectedVariantId: string | null;
+  onSelectVariant: (variant: WsConcreteMeasurement) => void;
 }) {
-  const hasRows = elements.length > 0 || pendingVariants.length > 0;
+  // Every individual variant gets its own row — no summing across a category.
+  const assignedRows = elements.flatMap((el) => el.variants);
+  const hasRows = assignedRows.length > 0 || pendingVariants.length > 0;
 
   return (
     <table className="w-full">
       <thead>
         <tr className="border-b border-slate-200 bg-slate-50/80">
-          {["Element", "Variants", "Measured", "Volume", "Rebar"].map((h) => (
+          {["Element", "Count", "Length", "Area", "Volume", "Rebar"].map((h) => (
             <th
               key={h}
               className="px-3 py-2 text-left text-[10px] font-bold uppercase tracking-wider text-slate-400"
@@ -130,31 +123,31 @@ function MeasurementTable({
       <tbody>
         {!hasRows && (
           <tr>
-            <td colSpan={5} className="px-3 py-4 text-center text-[12px] text-slate-400 italic">
+            <td colSpan={6} className="px-3 py-4 text-center text-[12px] text-slate-400 italic">
               No measurements yet. Apply &amp; Continue to see rows here.
             </td>
           </tr>
         )}
-        {elements.map((el) => (
-          <TableRow
-            key={el.id}
-            element={el.name}
-            label={variantLabel(el)}
-            measured={measuredTotal(el.variants, distanceUnit)}
-            volume={volumeTotal(el.variants)}
-            rebar={rebarSummary(el.variants)}
+        {assignedRows.map((v) => (
+          <VariantRow
+            key={v.id}
+            variant={v}
+            distanceUnit={distanceUnit}
+            inProgress={false}
+            selected={selectedVariantId === v.id}
+            onSelect={() => onSelectVariant(v)}
           />
         ))}
-        {pendingVariants.length > 0 && (
-          <TableRow
-            element={scaleWhat}
-            label={`${pendingVariants.length} variant${pendingVariants.length !== 1 ? "s" : ""}`}
-            measured={measuredTotal(pendingVariants, distanceUnit)}
-            volume={volumeTotal(pendingVariants)}
-            rebar={rebarSummary(pendingVariants)}
+        {pendingVariants.map((v) => (
+          <VariantRow
+            key={v.id}
+            variant={v}
+            distanceUnit={distanceUnit}
             inProgress
+            selected={selectedVariantId === v.id}
+            onSelect={() => onSelectVariant(v)}
           />
-        )}
+        ))}
       </tbody>
     </table>
   );
@@ -165,18 +158,24 @@ function MeasurementTable({
 export function LiveMeasurementsPanel({
   elements,
   pendingVariants,
-  scaleWhat,
   distanceUnit,
+  selectedVariantId,
+  onSelectVariant,
 }: {
   elements: CreatedElement[];
   pendingVariants: WsConcreteMeasurement[];
-  scaleWhat: string;
+  /** Kept for backwards-compat callers; no longer used for display since every
+   *  row now shows its own measureType instead of one shared category name. */
+  scaleWhat?: string;
   distanceUnit: string;
+  selectedVariantId: string | null;
+  onSelectVariant: (variant: WsConcreteMeasurement) => void;
 }) {
   const [collapsed, setCollapsed] = useState(true);
   const [expanded, setExpanded] = useState(false);
 
-  const totalRows = elements.length + (pendingVariants.length > 0 ? 1 : 0);
+  const totalRows =
+    elements.reduce((s, el) => s + el.variants.length, 0) + pendingVariants.length;
 
   return (
     <>
@@ -222,8 +221,9 @@ export function LiveMeasurementsPanel({
             <MeasurementTable
               elements={elements}
               pendingVariants={pendingVariants}
-              scaleWhat={scaleWhat}
               distanceUnit={distanceUnit}
+              selectedVariantId={selectedVariantId}
+              onSelectVariant={onSelectVariant}
             />
           </div>
         )}
@@ -245,8 +245,9 @@ export function LiveMeasurementsPanel({
             <MeasurementTable
               elements={elements}
               pendingVariants={pendingVariants}
-              scaleWhat={scaleWhat}
               distanceUnit={distanceUnit}
+              selectedVariantId={selectedVariantId}
+              onSelectVariant={onSelectVariant}
             />
           </div>
           <div className="shrink-0 pt-3 border-t border-slate-100 flex items-center justify-between">

--- a/components/projects/workspace/components/MeasurementCanvas.tsx
+++ b/components/projects/workspace/components/MeasurementCanvas.tsx
@@ -111,6 +111,8 @@ export interface MeasurementCanvasProps {
   distanceUnit: string;
   activeColor: string;
   measurements: Measurement[];
+  /** Mark IDs to draw with a highlight glow — set by clicking a Live Measurements row */
+  highlightedIds?: ReadonlySet<string>;
   nextCountIndex: number;
   /** Changes whenever the active file or page changes — resets any in-progress drawing */
   pageKey: string;
@@ -135,6 +137,7 @@ export function MeasurementCanvas({
   distanceUnit,
   activeColor,
   measurements,
+  highlightedIds,
   nextCountIndex,
   pageKey,
   onCalibrationUpdate,
@@ -306,6 +309,14 @@ export function MeasurementCanvas({
         setInProgress([]);
         onLiveLength?.(null);
         const pixLen = polylineLen(pts);
+        // TEMP diagnostic — remove once the pixel-to-real-unit bug is found.
+        console.log("[MEASUREMENT]", {
+          pdfZoom: pdfScale,
+          basePixelLength: pixLen,
+          scaleFactor,
+          resultingRealLength: pixLen / scaleFactor,
+          unit: distanceUnit,
+        });
         onMeasurementAdd({
           id: crypto.randomUUID(),
           type: "length",
@@ -405,10 +416,22 @@ export function MeasurementCanvas({
             {/* ── Completed measurements ─────────────────────────────────── */}
             {scaleFactor &&
               measurements.map((m) => {
+                const isHighlighted = highlightedIds?.has(m.id) ?? false;
+
                 if (m.type === "length") {
                   const c = centroid(m.points);
                   return (
                     <Group key={m.id}>
+                      {isHighlighted && (
+                        <Line
+                          points={flat(m.points)}
+                          stroke="#facc15"
+                          strokeWidth={SW * 3}
+                          opacity={0.55}
+                          lineCap="round"
+                          lineJoin="round"
+                        />
+                      )}
                       <Line
                         points={flat(m.points)}
                         stroke={m.color}
@@ -434,6 +457,17 @@ export function MeasurementCanvas({
                   const c = centroid(m.points);
                   return (
                     <Group key={m.id}>
+                      {isHighlighted && (
+                        <Line
+                          points={flat(m.points)}
+                          closed
+                          stroke="#facc15"
+                          strokeWidth={SW * 3}
+                          opacity={0.55}
+                          lineCap="round"
+                          lineJoin="round"
+                        />
+                      )}
                       <Line
                         points={flat(m.points)}
                         closed
@@ -460,6 +494,15 @@ export function MeasurementCanvas({
                 if (m.type === "count") {
                   return (
                     <Group key={m.id}>
+                      {isHighlighted && (
+                        <Circle
+                          x={m.point.x}
+                          y={m.point.y}
+                          radius={CR * 1.8}
+                          fill="#facc15"
+                          opacity={0.5}
+                        />
+                      )}
                       <Circle
                         x={m.point.x}
                         y={m.point.y}

--- a/components/projects/workspace/workspaceSession.ts
+++ b/components/projects/workspace/workspaceSession.ts
@@ -30,6 +30,16 @@ export interface VariantCanvasMeasurement {
   measurementIds: string[];
 }
 
+// ─── Scale calibration snapshot — same shape the backend's canvas.calibration
+// expects, carried on each variant so it can be sent along at assign-time
+// instead of relying on a separate backend session-level record. ─────────────
+
+export interface VariantCalibration {
+  knownDistance: number;
+  pixelDistance: number;
+  unit: string;
+}
+
 // ─── A single saved variant (one "Apply & Continue" click) ───────────────────
 
 export interface WsConcreteMeasurement {
@@ -39,6 +49,7 @@ export interface WsConcreteMeasurement {
   concreteFields: Record<string, string>;
   rebar: VariantRebar | null;
   canvas: VariantCanvasMeasurement;
+  calibration: VariantCalibration | null;
   sessionId: string | null;
   drawingId: string | null;
   pageNumber: number;
@@ -137,5 +148,53 @@ export function clearSession(projectId: string): void {
   try {
     localStorage.removeItem(sessionKey(projectId));
     localStorage.removeItem(legacyElementsKey(projectId));
+  } catch {}
+}
+
+// ─── Page-scoped calibration ────────────────────────────────────────────────
+// Calibration is applied entirely on the frontend now (no backend call at Apply
+// Scale time), so it needs its own per-page storage the same way raw canvas
+// marks already have (useCanvasMeasurements) — otherwise every page would
+// share one flat scale value and a reload would restore the wrong page's scale
+// (or none at all).
+
+export interface PageCalibrationData {
+  knownDistance: string;
+  distanceUnit: string;
+  scaleInfo: string;
+  scaleLocked: boolean;
+}
+
+const calibrationKey = (drawingId: string, page: number) =>
+  `ws-calibration-v1-${drawingId}-p${page}`;
+
+export function loadPageCalibration(
+  drawingId: string,
+  page: number,
+): PageCalibrationData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(calibrationKey(drawingId, page));
+    return raw ? (JSON.parse(raw) as PageCalibrationData) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function savePageCalibration(
+  drawingId: string,
+  page: number,
+  data: PageCalibrationData,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(calibrationKey(drawingId, page), JSON.stringify(data));
+  } catch {}
+}
+
+export function clearPageCalibration(drawingId: string, page: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(calibrationKey(drawingId, page));
   } catch {}
 }

--- a/store/slices/manualWizardSlice.ts
+++ b/store/slices/manualWizardSlice.ts
@@ -82,10 +82,13 @@ const manualWizardSlice = createSlice({
       // PDFs start with no pages — DrawingPreloader eagerly counts them via pdf.js.
       // All other formats (image, bim-3d, cad-2d) default to 1 view immediately;
       // viewers may call setDrawingPages later to update (e.g. IFC storeys).
+      const baseName = action.payload.name.replace(/\.[^.]+$/, "");
+      const truncatedName =
+        baseName.length > 10 ? `${baseName.slice(0, 10)}...` : baseName;
       const defaultPages =
         action.payload.category === "pdf"
           ? []
-          : [{ number: 1, label: "Page 1" }];
+          : [{ number: 1, label: `${truncatedName}1` }];
 
       const file: DrawingFile = {
         ...action.payload,


### PR DESCRIPTION
…ool, and page label shortening

Calibration now applies entirely on the frontend with no backend call at Apply Scale time — each saved variant carries its own calibration snapshot, sent to the backend only when its element is actually assigned. Added page-scoped calibration storage and a restoration effect so a reload doesn't lose scale state now that the backend is no longer the source of truth for it.

Live Measurements table now shows every individual variant as its own row instead of summing them into one aggregated line, with type-specific columns (Count/Length/Area) that stay empty when not applicable. Clicking a row highlights its marks on the drawing and shows that variant's own value in the Element panel instead of the live round's.

Switched wheel-zoom from React's synthetic onWheel to a real native non-passive listener so preventDefault reliably stops the browser's own pinch/ctrl-wheel zoom, and fixed the floating panel's scroll-vs-zoom handling to match. Added a rotate control next to the zoom buttons. Drawings sidebar page labels are now a truncated document name + page number instead of "Page N". Added temporary diagnostic logging around the pixel-to-real-unit calibration math to track down a reported scale discrepancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rotate drawings and images, with rotation-aware measurements and overlays.
  * Pan PDF drawings by dragging, including middle-button support.
  * Save calibration per drawing page for reuse.
  * Select measurement variants to view their saved values and highlight related canvas marks.
  * Display custom labels for non-PDF drawing pages.

* **Bug Fixes**
  * Prevent accidental browser zooming while interacting with drawings.
  * Preserve local page marks when finalized measurements are loaded.
  * Reset drawing rotation when switching pages or resuming sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->