### PR TITLE
fix: delete measurement marks with their rows, refetch elements after…

### DIFF
--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -111,7 +111,10 @@ import { DrawingCanvas } from "./components/DrawingCanvas";
 import { DrawingPreloader } from "./components/DrawingPreloader";
 import { FileRow } from "./components/FileRow";
 import { NewFolderDialog } from "./components/NewFolderDialog";
-import { useCanvasMeasurements } from "./hooks/useCanvasMeasurements";
+import {
+  useCanvasMeasurements,
+  removeMeasurementsFromStorage,
+} from "./hooks/useCanvasMeasurements";
 import type { MPoint } from "./components/types";
 
 const MeasurementCanvas = dynamic(
@@ -678,11 +681,33 @@ export function ProjectWorkspaceView({
     setSelectedVariantId((prev) => (prev === variant.id ? null : variant.id));
   }
 
+  // Erases the actual drawn marks (points/lines/polygons) a variant is made of,
+  // not just its table row. Resolves the variant's own drawing/page — which may
+  // not be the one currently on screen — and either updates the live canvas
+  // hook (active page) or patches that other page's localStorage entry directly.
+  function removeMarksForVariant(variant: WsConcreteMeasurement) {
+    const ids = variant.canvas.measurementIds;
+    if (ids.length === 0) return;
+    const drawing = drawings.find(
+      (d) => d.uploadedFileId === variant.drawingId || d.id === variant.drawingId,
+    );
+    const localDrawingId = drawing?.id ?? variant.drawingId;
+    if (!localDrawingId) return;
+    const isActivePage =
+      localDrawingId === selectedDrawingId && variant.pageNumber === selectedPage;
+    if (isActivePage) {
+      measurementHook.removeMeasurements(ids);
+    } else {
+      removeMeasurementsFromStorage(localDrawingId, variant.pageNumber, ids);
+    }
+  }
+
   // Live Measurements row delete — local storage only, matches the same
   // localStorage-first model the rest of the measurement data now uses.
   // Handles both pending (not yet assigned) and already-assigned variants.
   function handleDeleteVariant(variant: WsConcreteMeasurement) {
     setSelectedVariantId((prev) => (prev === variant.id ? null : prev));
+    removeMarksForVariant(variant);
 
     setConcreteMeasurements((prev) => {
       if (!prev.some((v) => v.id === variant.id)) return prev;
@@ -708,10 +733,11 @@ export function ProjectWorkspaceView({
   // every assigned element's variants — local storage only, per element record
   // metadata (name/category) is kept, only the measurement data is wiped.
   function handleClearAllVariants() {
-    const totalRows =
-      concreteMeasurements.length +
-      elements.reduce((s, el) => s + el.variants.length, 0);
-    if (totalRows === 0) return;
+    const allVariants = [
+      ...concreteMeasurements,
+      ...elements.flatMap((el) => el.variants),
+    ];
+    if (allVariants.length === 0) return;
     if (
       !window.confirm(
         "Clear all measurements from this table? This can't be undone.",
@@ -719,6 +745,8 @@ export function ProjectWorkspaceView({
     ) {
       return;
     }
+
+    for (const variant of allVariants) removeMarksForVariant(variant);
 
     setSelectedVariantId(null);
     setConcreteMeasurements([]);
@@ -983,113 +1011,113 @@ export function ProjectWorkspaceView({
   ]);
 
   // ── Global element loader: merge assigned elements from ALL project sessions ──
-  // Runs once after the project document loads. Fetches every session in parallel
-  // and aggregates their assigned elements so the Elements tab shows all work
-  // regardless of which page is currently active.
+  // Fetches every session in parallel and aggregates their assigned elements so
+  // the Elements tab shows all work regardless of which page is currently active.
+  // Exposed as a stable callback (not just an effect body) so anything that
+  // mutates elements server-side — e.g. deleting one — can re-invoke it to
+  // resync the sidebar list with the backend instead of trusting local state.
+  const loadProjectElements = useCallback(async () => {
+    const sessionsResult = await fetchProjectSessions(projectId);
+    if (!("data" in sessionsResult) || !sessionsResult.data?.data?.length)
+      return;
+
+    const sessionIds = sessionsResult.data.data.map((s) => s._id);
+    const sessionResults = await Promise.all(
+      sessionIds.map((id) => fetchSessionById(id)),
+    );
+
+    const assignedElementMap = new Map<
+      string,
+      { meta: CreatedElement; variantMap: Map<string, WsConcreteMeasurement> }
+    >();
+    const pendingVariantsMap = new Map<string, WsConcreteMeasurement>();
+
+    for (const result of sessionResults) {
+      if (!("data" in result) || !result.data?.data) continue;
+      const { elements, session: sessionData } = result.data.data;
+      const sid = sessionData._id;
+
+      for (const el of elements) {
+        const attrs = el.attributes ?? {};
+        const snapshotStr = attrs._snapshot as string | undefined;
+        if (!snapshotStr) continue;
+
+        let parsedVariant: WsConcreteMeasurement | null = null;
+        try {
+          parsedVariant = JSON.parse(snapshotStr) as WsConcreteMeasurement;
+        } catch {
+          continue;
+        }
+
+        if (attrs.pending === true) {
+          if (!pendingVariantsMap.has(parsedVariant.id)) {
+            pendingVariantsMap.set(parsedVariant.id, parsedVariant);
+          }
+        } else {
+          const eid = attrs.elementId as string | undefined;
+          const elementName = attrs.elementName as string | undefined;
+          if (!eid || !elementName) continue;
+
+          if (!assignedElementMap.has(eid)) {
+            assignedElementMap.set(eid, {
+              meta: {
+                id: eid,
+                name: elementName,
+                category: (attrs.elementCategory as string) ?? "Substructure",
+                categoryFolder:
+                  (attrs.categoryFolder as string) ?? elementName,
+                measurementUnit: (attrs.measurementUnit as string) ?? "items",
+                variants: [],
+                sessionId: sid,
+                drawingId: parsedVariant.drawingId,
+                pageNumber: parsedVariant.pageNumber,
+                createdAt: parsedVariant.savedAt,
+              },
+              variantMap: new Map(),
+            });
+          }
+
+          const entry = assignedElementMap.get(eid)!;
+          if (!entry.variantMap.has(parsedVariant.id)) {
+            entry.variantMap.set(parsedVariant.id, parsedVariant);
+          }
+        }
+      }
+    }
+
+    const reconstructedElements: CreatedElement[] = Array.from(
+      assignedElementMap.values(),
+    ).map(({ meta, variantMap }) => ({
+      ...meta,
+      variants: Array.from(variantMap.values()),
+    }));
+
+    const reconstructedPending = Array.from(pendingVariantsMap.values());
+
+    setElements(reconstructedElements);
+    if (reconstructedPending.length > 0) {
+      setConcreteMeasurements(reconstructedPending);
+    } else {
+      // Backend has no pending variants — fall back to localStorage for measurements
+      // saved in this session that weren't yet assigned to an element (e.g. after a
+      // hard refresh before assignment was completed).
+      const localPending = loadSession(projectId).concreteMeasurements;
+      if (localPending && localPending.length > 0) {
+        setConcreteMeasurements(localPending);
+      }
+    }
+    // fetchProjectSessions and fetchSessionById are stable references from RTK Query lazy hooks
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  // Runs once after the project document loads.
   const projectElementsLoaded = useRef(false);
   useEffect(() => {
     if (projectElementsLoaded.current) return;
     if (!backendProject?._id) return;
     projectElementsLoaded.current = true;
-
-    async function loadAllElements() {
-      const sessionsResult = await fetchProjectSessions(projectId);
-      if (!("data" in sessionsResult) || !sessionsResult.data?.data?.length)
-        return;
-
-      const sessionIds = sessionsResult.data.data.map((s) => s._id);
-      const sessionResults = await Promise.all(
-        sessionIds.map((id) => fetchSessionById(id)),
-      );
-
-      const assignedElementMap = new Map<
-        string,
-        { meta: CreatedElement; variantMap: Map<string, WsConcreteMeasurement> }
-      >();
-      const pendingVariantsMap = new Map<string, WsConcreteMeasurement>();
-
-      for (const result of sessionResults) {
-        if (!("data" in result) || !result.data?.data) continue;
-        const { elements, session: sessionData } = result.data.data;
-        const sid = sessionData._id;
-
-        for (const el of elements) {
-          const attrs = el.attributes ?? {};
-          const snapshotStr = attrs._snapshot as string | undefined;
-          if (!snapshotStr) continue;
-
-          let parsedVariant: WsConcreteMeasurement | null = null;
-          try {
-            parsedVariant = JSON.parse(snapshotStr) as WsConcreteMeasurement;
-          } catch {
-            continue;
-          }
-
-          if (attrs.pending === true) {
-            if (!pendingVariantsMap.has(parsedVariant.id)) {
-              pendingVariantsMap.set(parsedVariant.id, parsedVariant);
-            }
-          } else {
-            const eid = attrs.elementId as string | undefined;
-            const elementName = attrs.elementName as string | undefined;
-            if (!eid || !elementName) continue;
-
-            if (!assignedElementMap.has(eid)) {
-              assignedElementMap.set(eid, {
-                meta: {
-                  id: eid,
-                  name: elementName,
-                  category: (attrs.elementCategory as string) ?? "Substructure",
-                  categoryFolder:
-                    (attrs.categoryFolder as string) ?? elementName,
-                  measurementUnit: (attrs.measurementUnit as string) ?? "items",
-                  variants: [],
-                  sessionId: sid,
-                  drawingId: parsedVariant.drawingId,
-                  pageNumber: parsedVariant.pageNumber,
-                  createdAt: parsedVariant.savedAt,
-                },
-                variantMap: new Map(),
-              });
-            }
-
-            const entry = assignedElementMap.get(eid)!;
-            if (!entry.variantMap.has(parsedVariant.id)) {
-              entry.variantMap.set(parsedVariant.id, parsedVariant);
-            }
-          }
-        }
-      }
-
-      const reconstructedElements: CreatedElement[] = Array.from(
-        assignedElementMap.values(),
-      ).map(({ meta, variantMap }) => ({
-        ...meta,
-        variants: Array.from(variantMap.values()),
-      }));
-
-      const reconstructedPending = Array.from(pendingVariantsMap.values());
-
-      if (reconstructedElements.length > 0) {
-        setElements(reconstructedElements);
-      }
-      if (reconstructedPending.length > 0) {
-        setConcreteMeasurements(reconstructedPending);
-      } else {
-        // Backend has no pending variants — fall back to localStorage for measurements
-        // saved in this session that weren't yet assigned to an element (e.g. after a
-        // hard refresh before assignment was completed).
-        const localPending = loadSession(projectId).concreteMeasurements;
-        if (localPending && localPending.length > 0) {
-          setConcreteMeasurements(localPending);
-        }
-      }
-    }
-
-    loadAllElements();
-    // fetchProjectSessions and fetchSessionById are stable references from RTK Query lazy hooks
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [backendProject?._id, projectId]);
+    loadProjectElements();
+  }, [backendProject?._id, loadProjectElements]);
 
   // ── Auto-save: upsert the current variant to the backend ─────────────────────
   // Called both by canvas-mark completions and by form field changes (debounced).
@@ -1867,9 +1895,15 @@ export function ProjectWorkspaceView({
       }
     }
 
+    for (const variant of el.variants) removeMarksForVariant(variant);
+
+    // Optimistic local removal so the sidebar updates instantly, then
+    // invalidate by re-fetching the project's sessions so the list reconciles
+    // with the backend's actual state rather than trusting local bookkeeping.
     const updatedElements = elements.filter((e) => e.id !== el.id);
     setElements(updatedElements);
     saveSession(projectId, { createdElements: updatedElements });
+    loadProjectElements();
 
     toast.success(`"${el.name}" deleted`);
     setDeletingElementId(null);

--- a/components/projects/workspace/components/types.ts
+++ b/components/projects/workspace/components/types.ts
@@ -143,9 +143,11 @@ export function computeVolume(
 }
 
 /**
- * Derives an area value for a variant: the actual traced polygon area when
- * the Area tool was used, otherwise a Height × Width fallback computed from
- * whatever concrete fields were recorded for it (e.g. Window/Door openings).
+ * Derives an area value for a variant:
+ *  - Area tool           → the actual traced polygon area.
+ *  - Height + Width both recorded → opening area (e.g. Windows/Doors).
+ *  - Length tool + Height only recorded → wall-run area, traced length × height
+ *    (e.g. Blockwork, Wall Finishes — categories with a Height field but no Width).
  */
 export function computeArea(
   fields: Record<string, string>,
@@ -154,7 +156,9 @@ export function computeArea(
   if (canvas.tool === "area") return canvas.area;
   const height = parseFloat(fields.height ?? "0") || 0;
   const width = parseFloat(fields.width ?? "0") || 0;
-  return height > 0 && width > 0 ? height * width : 0;
+  if (height > 0 && width > 0) return height * width;
+  if (canvas.tool === "length" && height > 0) return canvas.length * height;
+  return 0;
 }
 
 /**

--- a/components/projects/workspace/hooks/useCanvasMeasurements.ts
+++ b/components/projects/workspace/hooks/useCanvasMeasurements.ts
@@ -30,6 +30,30 @@ function makeKey(drawingId: string | null, page: number) {
   return `${drawingId ?? "none"}-${page}`;
 }
 
+/**
+ * Removes marks by id directly from a page's localStorage entry, for a page
+ * that isn't the currently active one (so there's no live hook/state to
+ * update through). Used when deleting a measurement variant that lives on a
+ * different drawing/page than the one on screen right now.
+ */
+export function removeMeasurementsFromStorage(
+  drawingId: string,
+  page: number,
+  ids: string[],
+): void {
+  if (typeof window === "undefined" || ids.length === 0) return;
+  const idSet = new Set(ids);
+  const data = loadPage(drawingId, page);
+  if (!data.measurements.some((m) => idSet.has(m.id))) return;
+  const next: PageMeasurements = {
+    ...data,
+    measurements: data.measurements.filter((m) => !idSet.has(m.id)),
+  };
+  try {
+    localStorage.setItem(storageKey(drawingId, page), JSON.stringify(next));
+  } catch {}
+}
+
 export function useCanvasMeasurements(drawingId: string | null, page: number) {
   // Load from localStorage exactly once on mount (lazy initializer)
   const [initialData] = useState<PageMeasurements>(
@@ -83,6 +107,15 @@ export function useCanvasMeasurements(drawingId: string | null, page: number) {
     }));
   }
 
+  function removeMeasurements(ids: string[]) {
+    if (ids.length === 0) return;
+    const idSet = new Set(ids);
+    push((cur) => ({
+      ...cur,
+      measurements: cur.measurements.filter((m) => !idSet.has(m.id)),
+    }));
+  }
+
   function clearMeasurements() {
     push((cur) => ({ ...cur, measurements: [] }));
   }
@@ -99,6 +132,7 @@ export function useCanvasMeasurements(drawingId: string | null, page: number) {
     setCalibration,
     addMeasurement,
     removeMeasurement,
+    removeMeasurements,
     clearMeasurements,
     resetWithData,
     undo,


### PR DESCRIPTION
… delete, wall-run area fallback

Row/element deletion in Live Measurements and the sidebar Elements list now erases the underlying canvas marks (including on pages other than the active one), not just the summary entry, so deleted geometry can't linger in localStorage as orphans. Deleting a sidebar element now re-fetches the project's sessions afterward so the list reconciles with the backend instead of trusting local bookkeeping alone. computeArea gains a length x height fallback for categories with a Height field but no Width (Blockwork, Wall Finishes), so area now shows up for those once Height is entered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted variants and elements now also remove their associated canvas measurements.
  * Clearing all variants reliably removes their saved canvas marks.
  * Project elements now refresh correctly after server-side deletions, including when no elements remain.
  * Wall-run measurements now calculate area using traced length and wall height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->