### PR TITLE
fix: pan cursor stuck on tool crosshair, raise upload cap to 200MB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ Currency, Project Type, Project Phase, Duration (months), Description.
 
 ### Step 2 — Drawing References (`StepDrawings.tsx`)
 - Drag-and-drop via `react-dropzone`
-- **Max 10 files, 20 MB each**
+- **Max 10 files, 200 MB each** (client-side cap — but PDFs/images still route through the
+  backend's `/uploads` endpoint, which hard-caps at 50 MB; only CAD/BIM formats routed through
+  `/bim/upload` support up to 200 MB. See "Known Issues" below.)
 - Accepted formats: `.pdf` `.jpg` `.jpeg` `.png` `.rvt` `.ifc` `.nwd` `.skp` `.fbx` `.obj` `.dwg` `.dxf` `.dgn`
 - Per-file state machine: `queued → uploading (%) → processing → complete | error`
 - Upload is **simulated** — see swap point below
@@ -616,6 +618,7 @@ export function MultiFormatViewer({ url }: { url: string }) {
 | `app/layout.tsx` has a modification | `app/` | Review before next push |
 | Drawing upload is simulated | `StepDrawings.tsx` | Swap point clearly marked with TODO comment |
 | View BOQ finalize — exact failure mode unknown | `ProjectWorkspaceView.tsx` | Button now shows specific error toasts (404/400/5xx); user needs to report which one appears |
+| Client-side upload cap (200 MB) exceeds what PDFs/images can actually clear | `StepDrawings.tsx` | All files (PDF, image, CAD/BIM) upload through the generic `/uploads` endpoint, which the backend hard-caps at 50 MB. A 50–200 MB PDF/image will pass the dropzone check and then fail at upload time. Only CAD/BIM formats get true 200 MB support, and only via the separate `/bim/upload` endpoint (APS translation flow), which `StepDrawings.tsx` doesn't call. |
 
 ---
 

--- a/components/projects/manual/StepDrawings.tsx
+++ b/components/projects/manual/StepDrawings.tsx
@@ -20,7 +20,7 @@ import { useUploadFileMutation } from "@/store/api/uploadApi";
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const MAX_FILES = 10;
-const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20 MB
+const MAX_SIZE_BYTES = 200 * 1024 * 1024; // 200 MB
 
 const ACCEPTED_TYPES: Record<string, string[]> = {
   "application/pdf": [".pdf"],
@@ -190,7 +190,7 @@ export function StepDrawings({ onBack, onSaveAndProceed, isSaving }: StepDrawing
               <p className="text-xs text-muted-foreground mt-1">
                 PDF, JPG, PNG, DWG, DXF, RVT, IFC, NWD, SKP…
               </p>
-              <p className="text-xs text-muted-foreground">Up to {MAX_FILES} files · 20 MB each</p>
+              <p className="text-xs text-muted-foreground">Up to {MAX_FILES} files · 200 MB each</p>
             </div>
           </div>
 

--- a/components/projects/workspace/ProjectWorkspaceView.tsx
+++ b/components/projects/workspace/ProjectWorkspaceView.tsx
@@ -315,7 +315,7 @@ function rebarToReinforcement(
       const match = b.size.match(/^([A-Z])(\d+)$/);
       return {
         barMark: b.id,
-        barCount: parseInt(b.count, 10) || 0,
+        barCount: Number.parseInt(b.count, 10) || 0,
         barType: match?.[1] ?? "Y",
         diameter: parseInt(match?.[2] ?? "16", 10),
         length: Math.round((parseFloat(b.depth) / 1000) * 1000) / 1000, // mm → m
@@ -516,7 +516,9 @@ export function ProjectWorkspaceView({
   // Whether the calibration/scale bar at the bottom is visible — auto-hides a
   // couple seconds after locking, brought back via the "Edit Calibration" button.
   const [showCalibrationBar, setShowCalibrationBar] = useState(true);
-  const calibrationBarHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const calibrationBarHideTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   const [showElementPanel, setShowElementPanel] = useState(false);
   const [concreteMeasurements, setConcreteMeasurements] = useState<
@@ -582,6 +584,11 @@ export function ProjectWorkspaceView({
     () => savedSession.elementPanelCollapsed ?? false,
   );
   const canvasAreaRef = useRef<HTMLDivElement>(null);
+  // Mirrors DrawingCanvas's internal pan-drag state so the measurement overlay
+  // (rendered here, on top of it) can also show a "grabbing" cursor while
+  // panning — otherwise the active tool's crosshair cursor never changes,
+  // even mid-drag, since the overlay owns cursor styling over its own area.
+  const [isPanningDrawing, setIsPanningDrawing] = useState(false);
   const elementPanelRef = useRef<HTMLDivElement>(null);
   const panelDragState = useRef<{
     startX: number;
@@ -595,8 +602,11 @@ export function ProjectWorkspaceView({
   const [expandedCategories, setExpandedCategories] = useState<string[]>([]);
   // Elements — populated by Phase 2 hydration from backend, never from localStorage
   const [elements, setElements] = useState<CreatedElement[]>([]);
-  const [deleteElementTarget, setDeleteElementTarget] = useState<CreatedElement | null>(null);
-  const [deletingElementId, setDeletingElementId] = useState<string | null>(null);
+  const [deleteElementTarget, setDeleteElementTarget] =
+    useState<CreatedElement | null>(null);
+  const [deletingElementId, setDeletingElementId] = useState<string | null>(
+    null,
+  );
 
   // ── Calibration points (received from canvas during calibration) ─────────────
   const [calibPtCount, setCalibPtCount] = useState<0 | 1 | 2>(0);
@@ -660,7 +670,9 @@ export function ProjectWorkspaceView({
   }
 
   // ── Click a Live Measurements row to bring its value + geometry back up ──────
-  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(null);
+  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(
+    null,
+  );
 
   const selectedVariant = useMemo(() => {
     if (!selectedVariantId) return null;
@@ -689,12 +701,14 @@ export function ProjectWorkspaceView({
     const ids = variant.canvas.measurementIds;
     if (ids.length === 0) return;
     const drawing = drawings.find(
-      (d) => d.uploadedFileId === variant.drawingId || d.id === variant.drawingId,
+      (d) =>
+        d.uploadedFileId === variant.drawingId || d.id === variant.drawingId,
     );
     const localDrawingId = drawing?.id ?? variant.drawingId;
     if (!localDrawingId) return;
     const isActivePage =
-      localDrawingId === selectedDrawingId && variant.pageNumber === selectedPage;
+      localDrawingId === selectedDrawingId &&
+      variant.pageNumber === selectedPage;
     if (isActivePage) {
       measurementHook.removeMeasurements(ids);
     } else {
@@ -721,7 +735,10 @@ export function ProjectWorkspaceView({
       const next = prev.map((el) => {
         if (!el.variants.some((v) => v.id === variant.id)) return el;
         changed = true;
-        return { ...el, variants: el.variants.filter((v) => v.id !== variant.id) };
+        return {
+          ...el,
+          variants: el.variants.filter((v) => v.id !== variant.id),
+        };
       });
       if (!changed) return prev;
       saveSession(projectId, { createdElements: next });
@@ -910,7 +927,9 @@ export function ProjectWorkspaceView({
     // Only treat it as genuinely calibrated when the calibration inputs that Apply
     // Scale actually sends (knownDistance + pixelDistance) are both present too.
     const isGenuinelyCalibrated =
-      !!backendScale && !!calibration?.knownDistance && !!calibration?.pixelDistance;
+      !!backendScale &&
+      !!calibration?.knownDistance &&
+      !!calibration?.pixelDistance;
 
     if (isGenuinelyCalibrated) {
       setGlobalScaleFactor(backendScale);
@@ -951,7 +970,10 @@ export function ProjectWorkspaceView({
         measurementHook.resetWithData({
           scaleFactor: isGenuinelyCalibrated ? backendScale : null,
           calibPts: null,
-          measurements: [...measurementHook.state.measurements, ...newFromBackend],
+          measurements: [
+            ...measurementHook.state.measurements,
+            ...newFromBackend,
+          ],
         });
       }
       // These marks belong to already-saved elements from a prior round —
@@ -996,8 +1018,10 @@ export function ProjectWorkspaceView({
       knownDistance: parseFloat(saved.knownDistance) || 0,
       pixelDistance: measurementHook.state.calibPts
         ? Math.hypot(
-            measurementHook.state.calibPts[1].x - measurementHook.state.calibPts[0].x,
-            measurementHook.state.calibPts[1].y - measurementHook.state.calibPts[0].y,
+            measurementHook.state.calibPts[1].x -
+              measurementHook.state.calibPts[0].x,
+            measurementHook.state.calibPts[1].y -
+              measurementHook.state.calibPts[0].y,
           )
         : 0,
       unit: toBackendDistanceUnit(saved.distanceUnit),
@@ -1064,8 +1088,7 @@ export function ProjectWorkspaceView({
                 id: eid,
                 name: elementName,
                 category: (attrs.elementCategory as string) ?? "Substructure",
-                categoryFolder:
-                  (attrs.categoryFolder as string) ?? elementName,
+                categoryFolder: (attrs.categoryFolder as string) ?? elementName,
                 measurementUnit: (attrs.measurementUnit as string) ?? "items",
                 variants: [],
                 sessionId: sid,
@@ -2007,7 +2030,10 @@ export function ProjectWorkspaceView({
 
     // Group by canvas tool — geometry type (and therefore what's valid to send)
     // depends on the tool, so each group becomes its own bundled request.
-    const groups = new Map<"count" | "length" | "area", WsConcreteMeasurement[]>();
+    const groups = new Map<
+      "count" | "length" | "area",
+      WsConcreteMeasurement[]
+    >();
     for (const variant of variants) {
       const list = groups.get(variant.canvas.tool) ?? [];
       list.push(variant);
@@ -2081,7 +2107,12 @@ export function ProjectWorkspaceView({
       if (pointGroups.length === 0) continue;
 
       const geometry: MeasurementGeometry = {
-        type: tool === "count" ? "multipoint" : tool === "length" ? "polyline" : "polygon",
+        type:
+          tool === "count"
+            ? "multipoint"
+            : tool === "length"
+              ? "polyline"
+              : "polygon",
         points: pointGroups.flat(),
         page,
       };
@@ -2108,7 +2139,6 @@ export function ProjectWorkspaceView({
       });
     }
   }
-
 
   // ── Session conflict resolution (409 on session create) ──────────────────────
 
@@ -2558,7 +2588,9 @@ export function ProjectWorkspaceView({
                     </TooltipTrigger>
                     <TooltipContent side="bottom" sideOffset={6}>
                       <p className="font-semibold text-xs">Deselect Tool</p>
-                      <p className="text-[10px] opacity-75 mt-0.5">Stop drawing with the active tool</p>
+                      <p className="text-[10px] opacity-75 mt-0.5">
+                        Stop drawing with the active tool
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </div>
@@ -2697,7 +2729,9 @@ export function ProjectWorkspaceView({
                                           <div className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
                                           <span className="text-[12px] text-slate-500">
                                             {el.variants.length} variant
-                                            {el.variants.length !== 1 ? "s" : ""}
+                                            {el.variants.length !== 1
+                                              ? "s"
+                                              : ""}
                                           </span>
                                         </div>
                                       </button>
@@ -2979,6 +3013,7 @@ export function ProjectWorkspaceView({
                   !(scaleFlowActive && !scaleLocked) &&
                   (!activeTool || activeTool === "text")
                 }
+                onPanningChange={setIsPanningDrawing}
                 onPageCountResolved={handlePageCountResolved}
                 measurementOverlay={
                   <MeasurementCanvas
@@ -2992,6 +3027,7 @@ export function ProjectWorkspaceView({
                     highlightedIds={highlightedMarkIds}
                     nextCountIndex={nextCountIndex}
                     pageKey={`${selectedDrawingId ?? "none"}-${selectedPage}`}
+                    isPanning={isPanningDrawing}
                     onCalibrationUpdate={handleCalibrationUpdate}
                     onMeasurementAdd={handleMeasurementAdd}
                     onLiveLength={setLiveDrawingLength}
@@ -3435,20 +3471,25 @@ export function ProjectWorkspaceView({
 
         <AlertDialog
           open={!!deleteElementTarget}
-          onOpenChange={(v) => { if (!v) setDeleteElementTarget(null); }}
+          onOpenChange={(v) => {
+            if (!v) setDeleteElementTarget(null);
+          }}
         >
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>Delete element?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will permanently delete &quot;{deleteElementTarget?.name}&quot; and all{" "}
-                {deleteElementTarget?.variants.length ?? 0} of its measurement variant
-                {deleteElementTarget?.variants.length !== 1 ? "s" : ""} from the project. This
-                cannot be undone.
+                This will permanently delete &quot;{deleteElementTarget?.name}
+                &quot; and all {deleteElementTarget?.variants.length ?? 0} of
+                its measurement variant
+                {deleteElementTarget?.variants.length !== 1 ? "s" : ""} from the
+                project. This cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel disabled={!!deletingElementId}>Cancel</AlertDialogCancel>
+              <AlertDialogCancel disabled={!!deletingElementId}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 onClick={(e) => {
                   e.preventDefault();

--- a/components/projects/workspace/components/DrawingCanvas.tsx
+++ b/components/projects/workspace/components/DrawingCanvas.tsx
@@ -40,6 +40,7 @@ export function DrawingCanvas({
   scale,
   rotation = 0,
   panEnabled = false,
+  onPanningChange,
   onPageCountResolved,
   measurementOverlay,
 }: {
@@ -51,6 +52,10 @@ export function DrawingCanvas({
   rotation?: 0 | 90 | 180 | 270;
   /** Click-and-drag panning — only offered when no measurement tool is actively drawing. */
   panEnabled?: boolean;
+  /** Fires whenever an active pan drag starts/stops — including middle-mouse
+   *  panning while a tool is active, so the measurement overlay's cursor
+   *  (rendered by the parent, on top of this component) can reflect it too. */
+  onPanningChange?: (panning: boolean) => void;
   onPageCountResolved: (id: string, numPages: number) => void;
   /** Konva measurement canvas — rendered only over PDF pages */
   measurementOverlay?: React.ReactNode;
@@ -90,6 +95,7 @@ export function DrawingCanvas({
       moved: false,
     };
     setIsPanning(true);
+    onPanningChange?.(true);
     el.setPointerCapture(e.pointerId);
   }
 
@@ -107,6 +113,7 @@ export function DrawingCanvas({
   function handlePanPointerUp() {
     panState.current = null;
     setIsPanning(false);
+    onPanningChange?.(false);
   }
 
   if (!drawing) {
@@ -129,7 +136,7 @@ export function DrawingCanvas({
         onPointerCancel={handlePanPointerUp}
         style={panEnabled ? { touchAction: "none" } : undefined}
         className={`flex items-start justify-center h-full overflow-auto p-6 ${
-          panEnabled ? (isPanning ? "cursor-grabbing" : "cursor-grab") : ""
+          isPanning ? "cursor-grabbing" : panEnabled ? "cursor-grab" : ""
         }`}
       >
         {/* Wrapper is inline so it sizes to the rendered page, not the scroll container.

--- a/components/projects/workspace/components/MeasurementCanvas.tsx
+++ b/components/projects/workspace/components/MeasurementCanvas.tsx
@@ -116,6 +116,9 @@ export interface MeasurementCanvasProps {
   nextCountIndex: number;
   /** Changes whenever the active file or page changes — resets any in-progress drawing */
   pageKey: string;
+  /** True while the drawing is being click-dragged to pan — overrides the tool
+   *  cursor with "grabbing" so the hand icon shows even mid-drag with a tool active. */
+  isPanning?: boolean;
   /** Fires when calibration points change. ptCount = 0|1|2 */
   onCalibrationUpdate: (
     basePxDist: number | null,
@@ -140,6 +143,7 @@ export function MeasurementCanvas({
   highlightedIds,
   nextCountIndex,
   pageKey,
+  isPanning = false,
   onCalibrationUpdate,
   onMeasurementAdd,
   onLiveLength,
@@ -396,7 +400,13 @@ export function MeasurementCanvas({
       ref={containerRef}
       className="absolute inset-0"
       style={{
-        cursor: snapToClose ? "pointer" : isInteractive ? "crosshair" : "default",
+        cursor: isPanning
+          ? "grabbing"
+          : snapToClose
+            ? "pointer"
+            : isInteractive
+              ? "crosshair"
+              : "default",
         pointerEvents: isInteractive ? "all" : "none",
       }}
     >


### PR DESCRIPTION
The measurement overlay hard-codes its own cursor based on the active tool, so a mid-drag pan (including middle-mouse panning while a tool is selected) never showed the grab/grabbing hand — the crosshair cursor just stayed put. Thread the drawing's pan state from DrawingCanvas up through ProjectWorkspaceView and back down into MeasurementCanvas so it can override the tool cursor with "grabbing" while an active pan is in progress.

Also raise the wizard's client-side upload size cap from 20MB to 200MB per request; noted in CLAUDE.md that PDFs/images still route through the backend's /uploads endpoint, which hard-caps at 50MB regardless.